### PR TITLE
Git fetch should use https protocol

### DIFF
--- a/recipes-core/iotedge-cli/iotedge-cli_1.0.5.bb
+++ b/recipes-core/iotedge-cli/iotedge-cli_1.0.5.bb
@@ -7,7 +7,7 @@ inherit cargo
 
 # how to get iotedge could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/iotedge/0.1.0"
-SRC_URI += "gitsm://git@github.com/azure/iotedge.git;protocol=ssh"
+SRC_URI += "gitsm://github.com/azure/iotedge.git;protocol=https"
 SRCREV = "d76e0316c6f324345d77c48a83ce836d09392699"
 S = "${WORKDIR}/git/edgelet/iotedge"
 CARGO_SRC_DIR="edgelet"

--- a/recipes-core/iotedge-daemon/iotedge-daemon_1.0.5.bb
+++ b/recipes-core/iotedge-daemon/iotedge-daemon_1.0.5.bb
@@ -7,7 +7,7 @@ inherit cargo
 
 # how to get iotedged could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/iotedged/0.1.0"
-SRC_URI += "gitsm://git@github.com/azure/iotedge.git;protocol=ssh"
+SRC_URI += "gitsm://github.com/azure/iotedge.git;protocol=https"
 SRCREV = "d76e0316c6f324345d77c48a83ce836d09392699"
 S = "${WORKDIR}/git/edgelet/iotedged"
 CARGO_SRC_DIR="iotedged"

--- a/recipes-core/libiothsm-std/libiothsm-std_1.0.5.bb
+++ b/recipes-core/libiothsm-std/libiothsm-std_1.0.5.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM=" \
 file://LICENSE;md5=b98fddd052bb2f5ddbcdbd417ffb26a8 \
 "
 
-SRC_URI += "gitsm://git@github.com/azure/iotedge.git;protocol=ssh"
+SRC_URI += "gitsm://github.com/azure/iotedge.git;protocol=https"
 SRCREV = "d76e0316c6f324345d77c48a83ce836d09392699"
 
 S = "${WORKDIR}/git/edgelet/hsm-sys/azure-iot-hsm-c"


### PR DESCRIPTION
Previously, the fetcher used `ssh` which requires a public key on the build machine.