### PR TITLE
iotedge-daemon: do not hardcode openssl libdir

### DIFF
--- a/recipes-core/iotedge-daemon/iotedge-daemon.inc
+++ b/recipes-core/iotedge-daemon/iotedge-daemon.inc
@@ -6,7 +6,7 @@ export SYSROOT = "${STAGING_DIR_TARGET}"
 export OpenSSLDir = "${STAGING_DIR_TARGET}/usr"
 export OPENSSL_DIR = "${STAGING_DIR_TARGET}/usr"
 export OPENSSL_INCLUDE_DIR = "${STAGING_DIR_TARGET}/usr/include"
-export OPENSSL_LIB_DIR = "${STAGING_DIR_TARGET}/usr/lib"
+export OPENSSL_LIB_DIR = "${STAGING_LIBDIR}"
 export BUILD_SOURCEVERSION="${SRCREV}"
 
 inherit systemd update-rc.d


### PR DESCRIPTION
Some distributions use lib64 for 64-bit targets as $BASELIB. Use
$STAGING_LIBDIR to pick the correct path automatically.

Signed-off-by: Abdur Rehman <abdur_rehman@mentor.com>