### PR TITLE
fix libssl.so: file not recognized

### DIFF
--- a/recipes-core/iotedge-cli/iotedge-cli.inc
+++ b/recipes-core/iotedge-cli/iotedge-cli.inc
@@ -1,6 +1,9 @@
 DEPENDS += "openssl10"
 
 export BUILD_SOURCEVERSION="${SRCREV}"
+export OPENSSL_DIR = "${STAGING_EXECPREFIXDIR}"
+export OpenSSLDir = "${STAGING_EXECPREFIXDIR}"
+export OPENSSL_ROOT_DIR = "${STAGING_EXECPREFIXDIR}"
 
 do_install () {
     # Binaries


### PR DESCRIPTION
fixes: https://github.com/Azure/meta-iotedge/issues/34