### PR TITLE
recipes-core/ioedge-cli: force to disable building unit tests

### DIFF
--- a/recipes-core/iotedge-cli/iotedge-cli.inc
+++ b/recipes-core/iotedge-cli/iotedge-cli.inc
@@ -1,6 +1,7 @@
 DEPENDS += "openssl10"
 
 export BUILD_SOURCEVERSION="${SRCREV}"
+export FORCE_NO_UNITTEST="On"
 
 do_install () {
     # Binaries


### PR DESCRIPTION
The build script by default forces to build unit tests
that could fail therefore let's force to disable it
because that's not needed for cross-compilation.