### PR TITLE
Replaced hardcoded user id to variable

### DIFF
--- a/recipes-core/iotedge-daemon/iotedge-daemon.inc
+++ b/recipes-core/iotedge-daemon/iotedge-daemon.inc
@@ -47,8 +47,10 @@ do_install () {
 
 inherit useradd
 USERADD_PACKAGES = "${PN}"
-USERADD_PARAM_${PN} = "-r -u 15580 -g iotedge -G docker -s /bin/false -d ${localstatedir}/lib/iotedge iotedge"
-GROUPADD_PARAM_${PN} = "-r -g 15580 iotedge"
+SERVICE_USER_ID ?= "15580"
+
+USERADD_PARAM_${PN} = "-r -u ${SERVICE_USER_ID} -g iotedge -G docker -s /bin/false -d ${localstatedir}/lib/iotedge iotedge"
+GROUPADD_PARAM_${PN} = "-r -g ${SERVICE_USER_ID} iotedge"
 
 FILES_${PN} += " \
     ${systemd_unitdir}/system/* \


### PR DESCRIPTION
Id's of service users should range in the span between SYS_UID_MIN and SYS_UID_MAX as they are otherwise considered "Extra users". Extra users are often considered temporary user which the system might clean up from time to time. 

``` bash
iot-gate-imx8:/etc/iotedge# cat /etc/login.defs |grep UID
UID_MIN                  1000
UID_MAX                 60000
SYS_UID_MIN               101
SYS_UID_MAX               999
SUB_UID_MIN                100000
SUB_UID_MAX             600100000
SUB_UID_COUNT               65536
```

I've kept the iotedge user id to 15580, but has moved it to a variable that can be customized in the local.conf.