### PR TITLE
iotedge-{cli,daemon}: fix build with newer meta-rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This layer depends on:
 ```
 URI: git://github.com/meta-rust/meta-rust.git
 branch: master
-revision: e4d25b98083bcecb94df6ee189a165d63ede7f3d
+revision: c72b2dda3a4f70ed257c7de9bedb4b04732970a4
 prio: default
 ```
 
@@ -29,19 +29,6 @@ branch: dunfell
 revision: HEAD
 prio: default
 ```
-
-If you use newer meta-rust and iotedge-{cli,daemon} fail because of:
-#![deny(rust_2018_idioms, warnings)]
-in various files, then select older than current (1.47.0) version of rust:
-RUST_VERSION = "1.41.0"
-PREFERRED_VERSION_rust-native ?= "${RUST_VERSION}"
-PREFERRED_VERSION_rust-cross-${TARGET_ARCH} ?= "${RUST_VERSION}"
-PREFERRED_VERSION_rust-llvm-native ?= "${RUST_VERSION}"
-PREFERRED_VERSION_libstd-rs ?= "${RUST_VERSION}"
-PREFERRED_VERSION_cargo-native ?= "${RUST_VERSION}"
-
-or work around this issue in source with do_compile_prepend():
-find ${WORKDIR}/iotedge-${PV} -name "*.rs" -exec sed -i 's/idioms, warnings)/idioms)/g' {} \;
 
 Adding the meta-iotedge layer to your build
 =================================================

--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ revision: HEAD
 prio: default
 ```
 
+If you use newer meta-rust and iotedge-{cli,daemon} fail because of:
+#![deny(rust_2018_idioms, warnings)]
+in various files, then select older than current (1.47.0) version of rust:
+RUST_VERSION = "1.41.0"
+PREFERRED_VERSION_rust-native ?= "${RUST_VERSION}"
+PREFERRED_VERSION_rust-cross-${TARGET_ARCH} ?= "${RUST_VERSION}"
+PREFERRED_VERSION_rust-llvm-native ?= "${RUST_VERSION}"
+PREFERRED_VERSION_libstd-rs ?= "${RUST_VERSION}"
+PREFERRED_VERSION_cargo-native ?= "${RUST_VERSION}"
+
+or work around this issue in source with do_compile_prepend():
+find ${WORKDIR}/iotedge-${PV} -name "*.rs" -exec sed -i 's/idioms, warnings)/idioms)/g' {} \;
+
 Adding the meta-iotedge layer to your build
 =================================================
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This layer depends on:
 ```
 URI: git://github.com/meta-rust/meta-rust.git
 branch: master
-revision: c72b2dda3a4f70ed257c7de9bedb4b04732970a4
+revision: HEAD
 prio: default
 ```
 

--- a/builds/checkin.yaml
+++ b/builds/checkin.yaml
@@ -19,6 +19,6 @@ jobs:
       - script: scripts/fetch.sh dunfell
         displayName: Fetch
         env:
-          METARUST_REV: 'e4d25b98083bcecb94df6ee189a165d63ede7f3d'
+          METARUST_REV: 'c72b2dda3a4f70ed257c7de9bedb4b04732970a4'
       - script: scripts/build.sh
         displayName: Build

--- a/builds/checkin.yaml
+++ b/builds/checkin.yaml
@@ -19,6 +19,6 @@ jobs:
       - script: scripts/fetch.sh dunfell
         displayName: Fetch
         env:
-          METARUST_REV: 'c72b2dda3a4f70ed257c7de9bedb4b04732970a4'
+          METARUST_REV: 'refs/remotes/origin/master'
       - script: scripts/build.sh
         displayName: Build

--- a/recipes-core/iotedge-cli/iotedge-cli.inc
+++ b/recipes-core/iotedge-cli/iotedge-cli.inc
@@ -7,6 +7,6 @@ export LIBIOTHSM_NOBUILD="On"
 do_install () {
     # Binaries
     install -d  "${D}${bindir}"
-    install -m 755 "${WORKDIR}/iotedge-${PV}/edgelet/target/${CARGO_TARGET_SUBDIR}/iotedge" ${D}${bindir}/iotedge
+    install -m 755 "${B}/target/${CARGO_TARGET_SUBDIR}/iotedge" ${D}${bindir}/iotedge
 }
 

--- a/recipes-core/iotedge-cli/iotedge-cli_1.0.9.4.bb
+++ b/recipes-core/iotedge-cli/iotedge-cli_1.0.9.4.bb
@@ -235,13 +235,13 @@ SRC_URI += " \
 "
 
 SRCREV_FORMAT .= "_hyperlocal-windows"
-SRCREV_hyperlocal-windows = "${AUTOREV}"
+SRCREV_hyperlocal-windows = "2bd432bbbfb5b1cf38429733dd9a593c7b97a850"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/hyperlocal-windows"
 SRCREV_FORMAT .= "_mio-uds-windows"
-SRCREV_mio-uds-windows = "${AUTOREV}"
+SRCREV_mio-uds-windows = "87a4a9970e668fdbe9205f4039967e175182c70e"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/mio-uds-windows"
 SRCREV_FORMAT .= "_tokio-uds-windows"
-SRCREV_tokio-uds-windows = "${AUTOREV}"
+SRCREV_tokio-uds-windows = "b689a914dbaa905f359f89200c01fed7a6c8df3f"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/tokio-uds-windows"
 
 LIC_FILES_CHKSUM=" \

--- a/recipes-core/iotedge-cli/iotedge-cli_1.0.9.4.bb
+++ b/recipes-core/iotedge-cli/iotedge-cli_1.0.9.4.bb
@@ -244,6 +244,23 @@ SRCREV_FORMAT .= "_tokio-uds-windows"
 SRCREV_tokio-uds-windows = "b689a914dbaa905f359f89200c01fed7a6c8df3f"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/tokio-uds-windows"
 
+# Lower unused_attributes from error (implied by deny(warnings)) to allow, because
+# rust_2018_idioms is for crate level only since:
+# https://github.com/rust-lang/rust/pull/73300
+# causing:
+# error: deny(rust_2018_idioms) is ignored unless specified at crate level
+# with rust 1.46.0 and newer
+RUSTFLAGS += "-A unused_attributes"
+
+# Lower deprecated from error (implied by deny(warnings)) to allow, because
+# Error::description is deprecated since 1.42.0 with https://github.com/rust-lang/rust/pull/66919
+# error: use of deprecated associated function `std::error::Error::description`: use the Display impl or to_string()
+#    --> iotedge/src/support_bundle.rs:248:54
+#    --> iotedge/src/support_bundle.rs:302:54
+#    --> iotedge/src/support_bundle.rs:375:54
+#    --> iotedge/src/support_bundle.rs:457:54
+RUSTFLAGS += "-A deprecated"
+
 LIC_FILES_CHKSUM=" \
 file://../../LICENSE;md5=0f7e3b1308cb5c00b372a6e78835732d \
 file://../../THIRDPARTYNOTICES;md5=1cda6520d68499d4f60c7270445fe436 \

--- a/recipes-core/iotedge-cli/iotedge-cli_1.0.9.4.bb
+++ b/recipes-core/iotedge-cli/iotedge-cli_1.0.9.4.bb
@@ -6,7 +6,6 @@ SRC_URI[md5sum]="e5b28b34b721a9353ff623374678edf9"
 SRC_URI[sha256sum]="6fbf23972d243624b280546cda4d47a336988fb6beedf0bc44cb29498663edff"
 
 S = "${WORKDIR}/iotedge-${PV}/edgelet/iotedge"
-CARGO_SRC_DIR = "iotedge"
 
 SRC_URI += " \
     crate://crates.io/adler32/1.0.4 \

--- a/recipes-core/iotedge-daemon/iotedge-daemon.inc
+++ b/recipes-core/iotedge-daemon/iotedge-daemon.inc
@@ -18,7 +18,7 @@ INITSCRIPT_PARAMS_${PN} = "defaults"
 do_install () {
     # Binaries
     install -d  "${D}${bindir}"
-    install -m 755 "${WORKDIR}/iotedge-${PV}/edgelet/target/${CARGO_TARGET_SUBDIR}/iotedged" ${D}${bindir}/iotedged
+    install -m 755 "${B}/target/${CARGO_TARGET_SUBDIR}/iotedged" ${D}${bindir}/iotedged
 
     # Config file
     install -d "${D}${sysconfdir}/iotedge"

--- a/recipes-core/iotedge-daemon/iotedge-daemon_1.0.9.4.bb
+++ b/recipes-core/iotedge-daemon/iotedge-daemon_1.0.9.4.bb
@@ -235,13 +235,13 @@ SRC_URI += " \
 "
 
 SRCREV_FORMAT .= "_hyperlocal-windows"
-SRCREV_hyperlocal-windows = "${AUTOREV}"
+SRCREV_hyperlocal-windows = "2bd432bbbfb5b1cf38429733dd9a593c7b97a850"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/hyperlocal-windows"
 SRCREV_FORMAT .= "_mio-uds-windows"
-SRCREV_mio-uds-windows = "${AUTOREV}"
+SRCREV_mio-uds-windows = "87a4a9970e668fdbe9205f4039967e175182c70e"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/mio-uds-windows"
 SRCREV_FORMAT .= "_tokio-uds-windows"
-SRCREV_tokio-uds-windows = "${AUTOREV}"
+SRCREV_tokio-uds-windows = "b689a914dbaa905f359f89200c01fed7a6c8df3f"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/tokio-uds-windows"
 
 LIC_FILES_CHKSUM=" \

--- a/recipes-core/iotedge-daemon/iotedge-daemon_1.0.9.4.bb
+++ b/recipes-core/iotedge-daemon/iotedge-daemon_1.0.9.4.bb
@@ -244,6 +244,14 @@ SRCREV_FORMAT .= "_tokio-uds-windows"
 SRCREV_tokio-uds-windows = "b689a914dbaa905f359f89200c01fed7a6c8df3f"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/tokio-uds-windows"
 
+# Lower unused_attributes from error (implied by deny(warnings)) to warning, because
+# rust_2018_idioms is for crate level only since:
+# https://github.com/rust-lang/rust/pull/73300
+# causing:
+# error: deny(rust_2018_idioms) is ignored unless specified at crate level
+# with rust 1.46.0 and newer
+RUSTFLAGS += "-A unused_attributes"
+
 LIC_FILES_CHKSUM=" \
 file://../../LICENSE;md5=0f7e3b1308cb5c00b372a6e78835732d \
 file://../../THIRDPARTYNOTICES;md5=1cda6520d68499d4f60c7270445fe436 \

--- a/recipes-core/iotedge-daemon/iotedge-daemon_1.0.9.4.bb
+++ b/recipes-core/iotedge-daemon/iotedge-daemon_1.0.9.4.bb
@@ -6,7 +6,6 @@ SRC_URI[md5sum]="e5b28b34b721a9353ff623374678edf9"
 SRC_URI[sha256sum]="6fbf23972d243624b280546cda4d47a336988fb6beedf0bc44cb29498663edff"
 
 S = "${WORKDIR}/iotedge-${PV}/edgelet/iotedged"
-CARGO_SRC_DIR = "iotedged"
 
 SRC_URI += " \
     crate://crates.io/adler32/1.0.4 \

--- a/recipes-devtools/cargo/cargo_1.41.0.bbappend
+++ b/recipes-devtools/cargo/cargo_1.41.0.bbappend
@@ -1,2 +1,0 @@
-unset LIBGIT2_SYS_USE_PKG_CONFIG
-


### PR DESCRIPTION
* the binaries are built in ${B} since meta-rust commit:
  https://github.com/meta-rust/meta-rust/commit/a6733209953a390a09cf2f8e05e412c892815132
  adjust do_install to match that

Signed-off-by: Martin Jansa <martin.jansa@lge.com>