### PR TITLE
changed git fetch from nobranch/AUTOREV to main branch

### DIFF
--- a/recipes-core/iotedge-cli/iotedge-cli_1.1.8.bb
+++ b/recipes-core/iotedge-cli/iotedge-cli_1.1.8.bb
@@ -243,19 +243,19 @@ SRC_URI += " \
     crate://crates.io/ws2_32-sys/0.2.1 \
     crate://crates.io/yaml-rust/0.4.0 \
     crate://crates.io/zip/0.5.3 \
-    git://github.com/Azure/hyperlocal-windows;protocol=https;nobranch=1;name=hyperlocal-windows;destsuffix=hyperlocal-windows \
-    git://github.com/Azure/mio-uds-windows.git;protocol=https;nobranch=1;name=mio-uds-windows;destsuffix=mio-uds-windows \
-    git://github.com/Azure/tokio-uds-windows.git;protocol=https;nobranch=1;name=tokio-uds-windows;destsuffix=tokio-uds-windows \
+    git://github.com/Azure/hyperlocal-windows;protocol=https;branch=main;name=hyperlocal-windows;destsuffix=hyperlocal-windows \
+    git://github.com/Azure/mio-uds-windows.git;protocol=https;branch=main;name=mio-uds-windows;destsuffix=mio-uds-windows \
+    git://github.com/Azure/tokio-uds-windows.git;protocol=https;branch=main;name=tokio-uds-windows;destsuffix=tokio-uds-windows \
 "
 
 SRCREV_FORMAT .= "_hyperlocal-windows"
-SRCREV_hyperlocal-windows = "${AUTOREV}"
+SRCREV_hyperlocal-windows = "main"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/hyperlocal-windows"
 SRCREV_FORMAT .= "_mio-uds-windows"
-SRCREV_mio-uds-windows = "${AUTOREV}"
+SRCREV_mio-uds-windows = "main"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/mio-uds-windows"
 SRCREV_FORMAT .= "_tokio-uds-windows"
-SRCREV_tokio-uds-windows = "${AUTOREV}"
+SRCREV_tokio-uds-windows = "main"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/tokio-uds-windows"
 # 
 # End of section

--- a/recipes-core/iotedge-daemon/iotedge-daemon_1.1.8.bb
+++ b/recipes-core/iotedge-daemon/iotedge-daemon_1.1.8.bb
@@ -244,19 +244,19 @@ SRC_URI += " \
     crate://crates.io/ws2_32-sys/0.2.1 \
     crate://crates.io/yaml-rust/0.4.0 \
     crate://crates.io/zip/0.5.3 \
-    git://github.com/Azure/hyperlocal-windows;protocol=https;nobranch=1;name=hyperlocal-windows;destsuffix=hyperlocal-windows \
-    git://github.com/Azure/mio-uds-windows.git;protocol=https;nobranch=1;name=mio-uds-windows;destsuffix=mio-uds-windows \
-    git://github.com/Azure/tokio-uds-windows.git;protocol=https;nobranch=1;name=tokio-uds-windows;destsuffix=tokio-uds-windows \
+    git://github.com/Azure/hyperlocal-windows;protocol=https;branch=main;name=hyperlocal-windows;destsuffix=hyperlocal-windows \
+    git://github.com/Azure/mio-uds-windows.git;protocol=https;branch=main;name=mio-uds-windows;destsuffix=mio-uds-windows \
+    git://github.com/Azure/tokio-uds-windows.git;protocol=https;branch=main;name=tokio-uds-windows;destsuffix=tokio-uds-windows \
 "
 
 SRCREV_FORMAT .= "_hyperlocal-windows"
-SRCREV_hyperlocal-windows = "${AUTOREV}"
+SRCREV_hyperlocal-windows = "main"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/hyperlocal-windows"
 SRCREV_FORMAT .= "_mio-uds-windows"
-SRCREV_mio-uds-windows = "${AUTOREV}"
+SRCREV_mio-uds-windows = "main"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/mio-uds-windows"
 SRCREV_FORMAT .= "_tokio-uds-windows"
-SRCREV_tokio-uds-windows = "${AUTOREV}"
+SRCREV_tokio-uds-windows = "main"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/tokio-uds-windows"
 
 #


### PR DESCRIPTION
This fixes a recent bug introduced over the weekend which results in a bitbake expansion error. 
Specifically the error is the following,

bb.data_smart.ExpansionError: Failure expanding variable SRCPV, expression was ${@bb.fetch2.get_srcrev(d)} which triggered exception FetchError: Fetcher failure: Unable to resolve 'master' in upstream git repository in git ls-remote output for github.com/Azure/hyperlocal-windows

WARNING: /home/donovan/notUsed-bsp-dunfell/build-toradex/../layers/meta-iotedge/recipes-core/iotedge-daemon/iotedge-daemon_1.1.8.bb: Exception during build_dependencies for AUTOREV
WARNING: /home/donovan/notUsed-bsp-dunfell/build-toradex/../layers/meta-iotedge/recipes-core/iotedge-daemon/iotedge-daemon_1.1.8.bb: Error during finalise of /home/donovan/notUsed-bsp-dunfell/build-toradex/../layers/meta-iotedge/recipes-core/iotedge-daemon/iotedge-daemon_1.1.8.bb


The same error also occurs with mio-uds-windows and tokio-uds-windows.
This error also effects both iotedge-daemon_1.1.8.bb and iotedge-cli_1.1.8.bb