### PR TITLE
Use 1ES agent for Checkin gate

### DIFF
--- a/builds/checkin.yaml
+++ b/builds/checkin.yaml
@@ -11,9 +11,9 @@ jobs:
 ################################################################################
     displayName: Dunfell
     pool:
-      name: azureiotedge
+      name: "Azure-IoT-Edge-1ES-Hosted-Linux"
       demands:
-        - yocto
+      - ImageOverride -equals agent-aziotedge-rhel-8-msmoby
     timeoutInMinutes: 360
     steps:
       - script: scripts/fetch.sh dunfell

--- a/builds/checkin.yaml
+++ b/builds/checkin.yaml
@@ -24,6 +24,8 @@ jobs:
           METARUST_REV: '7ff669d8cedd83a2d3efb73073a63b0a7efffddc'
           STORAGE_PATH: $(mntStorageLocation)
       - script: |
+          # DevOps won't let you directly checkout the "self" repository to the mounted drive.
+          # The repo needs to be explicitly copied over after the checkout
           cp -r $(Build.SourcesDirectory)/* $(mntStorageLocation)
         displayName: Copy Files
       - script: scripts/build.sh
@@ -32,7 +34,7 @@ jobs:
           STORAGE_PATH: $(mntStorageLocation)
       - script: |
           echo "du"
-          sudo du -hsx 
+          sudo du -hsx /* | sort -rh | head -n 40
           echo ""
           echo "df"
           sudo df -ha /dev/*

--- a/builds/checkin.yaml
+++ b/builds/checkin.yaml
@@ -11,14 +11,30 @@ jobs:
 ################################################################################
     displayName: Dunfell
     pool:
-      name: "Azure-IoT-Edge-1ES-Hosted-Linux"
+      name: "iotedge-1es-hosted-linux"
       demands:
-      - ImageOverride -equals agent-aziotedge-rhel-8-msmoby
-    timeoutInMinutes: 360
+      - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+    timeoutInMinutes: 2400
+    variables:
+      mntStorageLocation: '/mnt/storage'
     steps:
       - script: scripts/fetch.sh dunfell
         displayName: Fetch
         env:
           METARUST_REV: '7ff669d8cedd83a2d3efb73073a63b0a7efffddc'
+          STORAGE_PATH: $(mntStorageLocation)
+      - script: |
+          cp -r $(Build.SourcesDirectory)/* $(mntStorageLocation)
+        displayName: Copy Files
       - script: scripts/build.sh
         displayName: Build
+        env:
+          STORAGE_PATH: $(mntStorageLocation)
+      - script: |
+          echo "du"
+          sudo du -hsx 
+          echo ""
+          echo "df"
+          sudo df -ha /dev/*
+        displayName: Debug disk
+        condition: always()

--- a/scripts/containerize.sh
+++ b/scripts/containerize.sh
@@ -30,10 +30,6 @@ tty -s && termint=t
 einfo "*** Ensuring local container is up to date"
 docker pull ${CONTAINER} > /dev/null || die "Failed to update docker container"
 
-echo "*** Show dir"
-pwd
-ls -la ${STORAGE_PATH}
-
 # Ensure we've got what we need for SSH_AUTH_SOCK
 if [[ -n ${SSH_AUTH_SOCK} ]]; then
 	SSH_AUTH_DIR=$(dirname $(readlink -f ${SSH_AUTH_SOCK}))

--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -114,10 +114,7 @@ for repo in ${REPOS}; do
 
 done
 
-echo "*** Show storage dir"
-pwd
 sudo chown -R $(id -u):$(id -g) ${STORAGE_PATH}
-ls -la ${STORAGE_PATH}
 
 rm -rf "${METAIOTEDGE_PATH}" || die "unable to clear old ${METAIOTEDGE_PATH}"
 ln -sf "../${METAIOTEDGE_URI}" "${METAIOTEDGE_PATH}" || \

--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -81,6 +81,19 @@ update_repo() {
 	echo "Updated '${path}' to '${rev}'"
 }
 
+# Fetch into /mnt/storage
+# https://github.com/crops/poky-container/blob/master/Dockerfile
+echo "*** Show working dir"
+echo ${PWD}
+ls -la ${PWD}
+
+sudo groupadd -g 70 usersetup 
+sudo useradd -N -m -u 70 -g 70 usersetup
+sudo useradd -ou $(id -u) -g$(id -g) pokyuser
+sudo usermod -aG root pokyuser
+sudo chown -R $(id -u):$(id -g) ${STORAGE_PATH}
+pushd ${STORAGE_PATH}
+
 # For each repo, do the work
 for repo in ${REPOS}; do
 	# upper case the name
@@ -103,6 +116,11 @@ for repo in ${REPOS}; do
 	update_repo "${repo_uri}" "${repo_path}" "${repo_rev}"
 
 done
+
+echo "*** Show storage dir"
+pwd
+sudo chown -R $(id -u):$(id -g) ${STORAGE_PATH}
+ls -la ${STORAGE_PATH}
 
 rm -rf "${METAIOTEDGE_PATH}" || die "unable to clear old ${METAIOTEDGE_PATH}"
 ln -sf "../${METAIOTEDGE_URI}" "${METAIOTEDGE_PATH}" || \

--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -81,12 +81,9 @@ update_repo() {
 	echo "Updated '${path}' to '${rev}'"
 }
 
-# Fetch into /mnt/storage
+# Base image dockerfile:
 # https://github.com/crops/poky-container/blob/master/Dockerfile
-echo "*** Show working dir"
-echo ${PWD}
-ls -la ${PWD}
-
+echo "*** Set permissions to be used for the build container"
 sudo groupadd -g 70 usersetup 
 sudo useradd -N -m -u 70 -g 70 usersetup
 sudo useradd -ou $(id -u) -g$(id -g) pokyuser


### PR DESCRIPTION
Previously the pipeline was run on the self-hosting pool, the ECSS team has mandate the self-hosting pools need to be retired in favor of the 1ES pools. This PR updates the checkin gate test agent to be running on 1ES VM instead of self-hosting VM.