### PR TITLE
Fix rust library location (fixes #182)

### DIFF
--- a/recipes-core/aziotd/aziotd.inc
+++ b/recipes-core/aziotd/aziotd.inc
@@ -85,7 +85,7 @@ GROUPADD_PARAM:${PN} = "-r aziotcs; "
 GROUPADD_PARAM:${PN} += "-r aziotks; "
 GROUPADD_PARAM:${PN} += "-r aziotid; "
 GROUPADD_PARAM:${PN} += "-r aziottpm; "
-RUSTFLAGS += "-Clink-arg=-Wl,-rpath,${libdir}/rustlib/${RUST_HOST_SYS}/lib"
+RUSTFLAGS += "-Clink-arg=-Wl,-rpath,${rustlibdir}"
 
 export SOCKET_DIR="/run/aziot"
 export USER_AZIOTID="aziotid"


### PR DESCRIPTION
The path to rust lib dir was hardcoded into the aziotd include file. Because the path was not matching the one used on rust side it, the services using shared rust libraries were failing and could not find the shared library.

This commit replaces the hardcoded value by the variable which tells rust (in this case cargo) where to place the compiled libs. This way, in case of future evolution of the rustc lib path, the up to date one will be used.

Linked with existing issue : #182 