### PR TITLE
Use ${rustlibdir} for rust library rpath (fixes #182)

### DIFF
--- a/recipes-core/aziotd/aziotd.inc
+++ b/recipes-core/aziotd/aziotd.inc
@@ -98,7 +98,7 @@ export USER_AZIOTTPM="aziottpm"
 
 # Set rpath to the location where aziot-keys installs libaziot_keys.so
 # Fixes: https://github.com/Azure/meta-iotedge/issues/182
-RUSTFLAGS += "-Clink-arg=-Wl,-rpath,${libdir}/rust"
+RUSTFLAGS += "-Clink-arg=-Wl,-rpath,${rustlibdir}"
 FILES:${PN} += " \
     ${systemd_unitdir}/system/* \
     ${bindir}/aziot-* \


### PR DESCRIPTION
Replace hardcoded rust lib path with the `${rustlibdir}` variable, which tracks the actual location cargo uses for compiled libraries. This ensures the rpath stays correct across Rust toolchain changes.

Based on the fix from #183 by @cramirez-actia (which targeted kirkstone), adapted for the main branch where the path was already partially updated.

Fixes #182
Supersedes #183 (for main branch)