### PR TITLE
Fix space-around-equal QA warnings

### DIFF
--- a/recipes-core/aziot-edged/aziot-edged.inc
+++ b/recipes-core/aziot-edged/aziot-edged.inc
@@ -1,7 +1,7 @@
 DEPENDS += "openssl iotedge aziotd systemd"
 RDEPENDS:${PN} += "iotedge aziotd aziot-keys systemd glibc-utils docker"
 
-export SOCKET_DIR="/run/aziot"
+export SOCKET_DIR = "/run/aziot"
 
 inherit systemd
 

--- a/recipes-core/aziot-keys/aziot-keys.inc
+++ b/recipes-core/aziot-keys/aziot-keys.inc
@@ -1,3 +1,3 @@
 DEPENDS += "openssl pkgconfig"
 
-SRC_URI+= " file://0001-Remove-panic.patch"
+SRC_URI += " file://0001-Remove-panic.patch"

--- a/recipes-core/aziotctl/aziotctl.inc
+++ b/recipes-core/aziotctl/aziotctl.inc
@@ -1,10 +1,10 @@
 DEPENDS += "openssl"
 
 export OPENSSL_DIR = "${STAGING_EXECPREFIXDIR}"
-export SOCKET_DIR="/run/aziot"
-export USER_AZIOTID="aziotid"
-export USER_AZIOTCS="aziotcs"
-export USER_AZIOTKS="aziotks"
-export USER_AZIOTTPM="aziottpm"
+export SOCKET_DIR = "/run/aziot"
+export USER_AZIOTID = "aziotid"
+export USER_AZIOTCS = "aziotcs"
+export USER_AZIOTKS = "aziotks"
+export USER_AZIOTTPM = "aziottpm"
 
-SRC_URI+= " file://0001-Remove-panic.patch"
+SRC_URI += " file://0001-Remove-panic.patch"

--- a/recipes-core/aziotd/aziotd.inc
+++ b/recipes-core/aziotd/aziotd.inc
@@ -90,11 +90,11 @@ GROUPADD_PARAM:${PN} += "-r -g 13625 aziotks; "
 GROUPADD_PARAM:${PN} += "-r -g 13626 aziotid; "
 GROUPADD_PARAM:${PN} += "-r -g 13627 aziottpm; "
 
-export SOCKET_DIR="/run/aziot"
-export USER_AZIOTID="aziotid"
-export USER_AZIOTCS="aziotcs"
-export USER_AZIOTKS="aziotks"
-export USER_AZIOTTPM="aziottpm"
+export SOCKET_DIR = "/run/aziot"
+export USER_AZIOTID = "aziotid"
+export USER_AZIOTCS = "aziotcs"
+export USER_AZIOTKS = "aziotks"
+export USER_AZIOTTPM = "aziottpm"
 
 # Set rpath to the location where aziot-keys installs libaziot_keys.so
 # Fixes: https://github.com/Azure/meta-iotedge/issues/182

--- a/recipes-core/iotedge/iotedge.inc
+++ b/recipes-core/iotedge/iotedge.inc
@@ -2,12 +2,12 @@ DEPENDS += "openssl aziotctl"
 RDEPENDS:${PN} += "aziotctl"
 
 export OPENSSL_DIR = "${STAGING_EXECPREFIXDIR}"
-export LIBIOTHSM_NOBUILD="On"
-export SOCKET_DIR="/run/aziot"
-export USER_AZIOTID="aziotid"
-export USER_AZIOTCS="aziotcs"
-export USER_AZIOTKS="aziotks"
-export USER_AZIOTTPM="aziottpm"
+export LIBIOTHSM_NOBUILD = "On"
+export SOCKET_DIR = "/run/aziot"
+export USER_AZIOTID = "aziotid"
+export USER_AZIOTCS = "aziotcs"
+export USER_AZIOTKS = "aziotks"
+export USER_AZIOTTPM = "aziottpm"
 
 SRC_URI += "file://0001-Remove-panic-abort-from-workspace-profiles.patch \
             file://0002-Work-around-Rust-1.78-dead_code-lint-issues.patch \


### PR DESCRIPTION
## Summary

Fixes #207.

Adds whitespace around the assignment operators in the recipe `.inc` files so the Yocto / OpenEmbedded [space-around-equal](https://docs.yoctoproject.org/ref-manual/qa-checks.html#space-around-equal) QA check no longer warns when building `meta-iotedge`.

These warnings were log noise only and did not affect builds, but newer bitbake/OpenEmbedded surfaces them and other layers keep their recipes clean of them.

## Changes

19 assignment lines across 5 files:

- `recipes-core/aziot-edged/aziot-edged.inc`
- `recipes-core/aziot-keys/aziot-keys.inc`
- `recipes-core/aziotctl/aziotctl.inc`
- `recipes-core/aziotd/aziotd.inc`
- `recipes-core/iotedge/iotedge.inc`

Two patterns fixed: `export VAR="..."` to `export VAR = "..."`, and `SRC_URI+= "..."` to `SRC_URI += "..."`. No functional change.

## Validation

`bitbake -p` (parse only) in the Scarthgap devcontainer parses all recipes with 0 errors after the change.
