### PR TITLE
validate-qemu: raise guest RAM from 256 MB default to 1 GB

### DIFF
--- a/scripts/validate-qemu.sh
+++ b/scripts/validate-qemu.sh
@@ -91,8 +91,13 @@ source ./poky/oe-init-build-env build >/dev/null 2>&1
 set -u
 
 # Start QEMU with slirp networking (automatically forwards host:2222 -> guest:22)
+# Bump guest RAM well above the qemux86-64 default (256 MB, no swap). The default
+# is too tight to run containerd + the container engine + `iotedge check`
+# together: the kernel thrashes in reclaim and GFP_ATOMIC allocations in the
+# network RX path start failing, which makes `iotedge check` crawl past its
+# 240s bound. Override with QEMU_MEM_MB if needed.
 echo "Starting QEMU with slirp networking (SSH on localhost:${SSH_PORT})..."
-runqemu "${MACHINE}" nographic slirp &
+runqemu "${MACHINE}" nographic slirp qemuparams="-m ${QEMU_MEM_MB:-1024}" &
 RUNQEMU_PID=$!
 
 # Wait for SSH to become available


### PR DESCRIPTION
## Problem

QEMU validation is slow and the guest kernel logs page-allocation failures during `iotedge check`:

```
kswapd0: page allocation failure: order:0, mode:0x820(GFP_ATOMIC)
containerd: page allocation failure: order:0, mode:0x820(GFP_ATOMIC)
...
Total swap = 0kB
65398 pages RAM   (~256 MB)
free:715          (~2.8 MB free)
(iotedge check exceeded 240s or returned non-zero; continuing)
```

The guest runs with the qemux86-64 default of **256 MB and no swap**. That isn't enough to run containerd, the container engine, and `iotedge check` at the same time. The kernel thrashes in reclaim (kswapd), and atomic allocations in the virtio-net RX path (`virtnet_poll` -> `try_fill_recv` -> `skb_page_frag_refill`) fail because they can't wait or reclaim. The reclaim thrash is also why `iotedge check` blows past its 240s bound and the validation drags.

## Fix

Pass `qemuparams="-m 1024"` to `runqemu`, raising the guest to 1 GB (overridable via `QEMU_MEM_MB`). `runqemu` parses the `-m` value and propagates it to both `QB_MEM` and the kernel `mem=` cmdline, so the guest and kernel agree on the larger size.

1 GB gives enough headroom for kswapd to keep up and the RX-path allocations to succeed, so `iotedge check` completes instead of timing out.

No host-side cost: the CI runner has ample RAM.
