### PR TITLE
Default static UID/GID on for 1.6, dynamic for 1.5 (configurable via IOTEDGE_STATIC_UIDS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,11 @@ On 32-bit ARM targets where OpenSSL is compiled with `_TIME_BITS=64`, the Rust `
 remove `-D_TIME_BITS=64` from OpenSSL flags. Fix: update the vendored `libc` crate to >= 0.2.179
 and set `RUST_LIBC_UNSTABLE_GNU_TIME_BITS=64`. See [#187](https://github.com/Azure/meta-iotedge/issues/187).
 
-**Static UIDs for aziotd users (opt-in)**
+**Static UIDs for aziotd users (version-dependent default)**
 
-By default, IoT Edge system users and groups use dynamically allocated UIDs/GIDs
-(legacy behavior). Set `IOTEDGE_STATIC_UIDS = "1"` in your distro config or
-`local.conf` to pin them to fixed values, which keeps ownership consistent across
-builds (important for A/B partition schemes and `[[principal]]` config references):
+IoT Edge system users and groups can be pinned to fixed UIDs/GIDs, which keeps
+ownership consistent across builds (important for A/B partition schemes and
+`[[principal]]` config references):
 
 | User / Group | UID / GID |
 | :----------- | --------: |
@@ -121,14 +120,21 @@ builds (important for A/B partition schemes and `[[principal]]` config reference
 | `aziotid` | 13626 |
 | `aziottpm` | 13627 |
 
+The default depends on the IoT Edge version. **1.6** (a new LTS line) defaults to
+static IDs, so the deterministic numbering is in place from the start of the line.
+**1.5.x** (already shipped) defaults to dynamic allocation, so existing fielded
+devices see no change. Set `IOTEDGE_STATIC_UIDS = "1"` (or `"0"`) in your distro
+config or `local.conf` to override either way.
+
 `edgeagentuser` and `edgehubuser` are always statically assigned (they predate the
 flag). The `docker` group is left dynamic because other layers may also create it.
 
 Enabling static UIDs on a device that previously ran dynamic IDs changes the
 on-disk ownership of persisted data under `/var/lib/aziot`. On A/B OTA systems that
 carry that data across the partition swap, the files end up owned by the wrong user
-until they are chowned to the new IDs, so the static IDs are opt-in to avoid this as
-an upgrade surprise. To override any ID, use a `.bbappend` with your own
+until they are chowned to the new IDs. This is a one-time change: once on static
+IDs the numbers never drift again, unlike dynamic allocation where they can shift
+on any rebuild. To override any individual ID, use a `.bbappend` with your own
 `USERADD_PARAM`/`GROUPADD_PARAM`. See [#130](https://github.com/Azure/meta-iotedge/issues/130).
 
 **Overriding `do_install:append` in recipes**

--- a/README.md
+++ b/README.md
@@ -104,11 +104,12 @@ On 32-bit ARM targets where OpenSSL is compiled with `_TIME_BITS=64`, the Rust `
 remove `-D_TIME_BITS=64` from OpenSSL flags. Fix: update the vendored `libc` crate to >= 0.2.179
 and set `RUST_LIBC_UNSTABLE_GNU_TIME_BITS=64`. See [#187](https://github.com/Azure/meta-iotedge/issues/187).
 
-**Static UIDs for aziotd users**
+**Static UIDs for aziotd users (opt-in)**
 
-All IoT Edge system users and groups are assigned static UIDs/GIDs so they remain
-consistent across builds (important for A/B partition schemes and `[[principal]]`
-config references):
+By default, IoT Edge system users and groups use dynamically allocated UIDs/GIDs
+(legacy behavior). Set `IOTEDGE_STATIC_UIDS = "1"` in your distro config or
+`local.conf` to pin them to fixed values, which keeps ownership consistent across
+builds (important for A/B partition schemes and `[[principal]]` config references):
 
 | User / Group | UID / GID |
 | :----------- | --------: |
@@ -120,9 +121,15 @@ config references):
 | `aziotid` | 13626 |
 | `aziottpm` | 13627 |
 
-The `docker` group is left dynamic because other layers may also create it.
-To override any ID, use a `.bbappend` with your own `USERADD_PARAM`/`GROUPADD_PARAM`.
-See [#130](https://github.com/Azure/meta-iotedge/issues/130).
+`edgeagentuser` and `edgehubuser` are always statically assigned (they predate the
+flag). The `docker` group is left dynamic because other layers may also create it.
+
+Enabling static UIDs on a device that previously ran dynamic IDs changes the
+on-disk ownership of persisted data under `/var/lib/aziot`. On A/B OTA systems that
+carry that data across the partition swap, the files end up owned by the wrong user
+until they are chowned to the new IDs, so the static IDs are opt-in to avoid this as
+an upgrade surprise. To override any ID, use a `.bbappend` with your own
+`USERADD_PARAM`/`GROUPADD_PARAM`. See [#130](https://github.com/Azure/meta-iotedge/issues/130).
 
 **Overriding `do_install:append` in recipes**
 

--- a/recipes-core/aziot-edged/aziot-edged.inc
+++ b/recipes-core/aziot-edged/aziot-edged.inc
@@ -50,12 +50,28 @@ do_install:append () {
 
 inherit useradd
 USERADD_PACKAGES = "${PN}"
-USERADD_PARAM:${PN} = "-r -u 13620 -g iotedge -c 'iotedge user' -G docker,systemd-journal,aziotcs,aziotks,aziottpm,aziotid -s /sbin/nologin -d ${localstatedir}/lib/aziot/edged iotedge; "
+
+# Optionally pin the iotedge user/group to a static UID/GID.
+#
+# Static IDs are required for stable [[principal]] config references and make
+# A/B partition upgrades deterministic, but switching an already-deployed device
+# from a dynamically-allocated ID to a static one changes the on-disk ownership
+# of persisted data under ${localstatedir}/lib/aziot, which must then be chowned.
+# To avoid surprising existing integrators, this is opt-in and defaults off
+# (legacy dynamic allocation). Set IOTEDGE_STATIC_UIDS = "1" in your distro or
+# local.conf to enable. See https://github.com/Azure/meta-iotedge/issues/130
+IOTEDGE_STATIC_UIDS ??= "0"
+IOTEDGE_UID_IOTEDGE = "${@'-u 13620 ' if d.getVar('IOTEDGE_STATIC_UIDS') == '1' else ''}"
+IOTEDGE_GID_IOTEDGE = "${@'-g 13620 ' if d.getVar('IOTEDGE_STATIC_UIDS') == '1' else ''}"
+
+USERADD_PARAM:${PN} = "-r ${IOTEDGE_UID_IOTEDGE}-g iotedge -c 'iotedge user' -G docker,systemd-journal,aziotcs,aziotks,aziottpm,aziotid -s /sbin/nologin -d ${localstatedir}/lib/aziot/edged iotedge; "
+# edgeagentuser/edgehubuser have been statically pinned since before the optional
+# flag existed; left unchanged to avoid a regression for existing builds.
 USERADD_PARAM:${PN} += "-r -g iotedge -c 'edgeAgent user' -s /bin/sh -u 13622 edgeagentuser; "
 USERADD_PARAM:${PN} += "-r -g iotedge -c 'edgeHub user' -s /bin/sh -u 13623 edgehubuser; "
 # Create both iotedge and docker groups - docker group is needed for iotedge user supplementary groups
-# Static GID for iotedge group; docker group left dynamic (shared with other layers)
-GROUPADD_PARAM:${PN} = "-r -g 13620 iotedge; -r docker"
+# iotedge GID is static only when IOTEDGE_STATIC_UIDS = "1"; docker group left dynamic (shared with other layers)
+GROUPADD_PARAM:${PN} = "-r ${IOTEDGE_GID_IOTEDGE}iotedge; -r docker"
 
 FILES:${PN} += " \
     ${systemd_unitdir}/system/* \

--- a/recipes-core/aziot-edged/aziot-edged.inc
+++ b/recipes-core/aziot-edged/aziot-edged.inc
@@ -57,10 +57,13 @@ USERADD_PACKAGES = "${PN}"
 # A/B partition upgrades deterministic, but switching an already-deployed device
 # from a dynamically-allocated ID to a static one changes the on-disk ownership
 # of persisted data under ${localstatedir}/lib/aziot, which must then be chowned.
-# To avoid surprising existing integrators, this is opt-in and defaults off
-# (legacy dynamic allocation). Set IOTEDGE_STATIC_UIDS = "1" in your distro or
-# local.conf to enable. See https://github.com/Azure/meta-iotedge/issues/130
-IOTEDGE_STATIC_UIDS ??= "0"
+# The default is version-dependent: 1.6 is a new LTS line, so it defaults ON
+# (the one-time move onto static IDs rides along with the major upgrade people
+# are already testing, and the IDs never drift again afterward). 1.5.x is an
+# already-shipped line, so it stays OFF to avoid changing on-disk ownership for
+# devices in the field. Override either way with IOTEDGE_STATIC_UIDS in your
+# distro or local.conf. See https://github.com/Azure/meta-iotedge/issues/130
+IOTEDGE_STATIC_UIDS ??= "${@'1' if (d.getVar('PV') or '').startswith('1.6') else '0'}"
 IOTEDGE_UID_IOTEDGE = "${@'-u 13620 ' if d.getVar('IOTEDGE_STATIC_UIDS') == '1' else ''}"
 IOTEDGE_GID_IOTEDGE = "${@'-g 13620 ' if d.getVar('IOTEDGE_STATIC_UIDS') == '1' else ''}"
 

--- a/recipes-core/aziotd/aziotd.inc
+++ b/recipes-core/aziotd/aziotd.inc
@@ -108,17 +108,33 @@ do_install:append  () {
 
 inherit useradd
 USERADD_PACKAGES = "${PN}"
-USERADD_PARAM:${PN} = "-r -u 13624 -g aziotcs -c 'aziot-certd user' -G aziotks -s /sbin/nologin -d ${localstatedir}/lib/aziot/certd aziotcs; "
-USERADD_PARAM:${PN} += "-r -u 13625 -g aziotks -c 'aziot-keyd user' -s /sbin/nologin -d ${localstatedir}/lib/aziot/keyd aziotks; "
-USERADD_PARAM:${PN} += "-r -u 13626 -g aziotid -c 'aziot-identityd user' -G aziotcs,aziotks,aziottpm -s /sbin/nologin -d ${localstatedir}/lib/aziot/identityd aziotid; "
+
+# Optionally pin the aziot service users/groups to static UIDs/GIDs.
+# Opt-in and defaults off (legacy dynamic allocation). See aziot-edged.inc and
+# https://github.com/Azure/meta-iotedge/issues/130 for the rationale and the
+# A/B upgrade ownership caveat. Set IOTEDGE_STATIC_UIDS = "1" to enable.
+IOTEDGE_STATIC_UIDS ??= "0"
+IOTEDGE_UID_AZIOTCS = "${@'-u 13624 ' if d.getVar('IOTEDGE_STATIC_UIDS') == '1' else ''}"
+IOTEDGE_UID_AZIOTKS = "${@'-u 13625 ' if d.getVar('IOTEDGE_STATIC_UIDS') == '1' else ''}"
+IOTEDGE_UID_AZIOTID = "${@'-u 13626 ' if d.getVar('IOTEDGE_STATIC_UIDS') == '1' else ''}"
+IOTEDGE_UID_AZIOTTPM = "${@'-u 13627 ' if d.getVar('IOTEDGE_STATIC_UIDS') == '1' else ''}"
+
+USERADD_PARAM:${PN} = "-r ${IOTEDGE_UID_AZIOTCS}-g aziotcs -c 'aziot-certd user' -G aziotks -s /sbin/nologin -d ${localstatedir}/lib/aziot/certd aziotcs; "
+USERADD_PARAM:${PN} += "-r ${IOTEDGE_UID_AZIOTKS}-g aziotks -c 'aziot-keyd user' -s /sbin/nologin -d ${localstatedir}/lib/aziot/keyd aziotks; "
+USERADD_PARAM:${PN} += "-r ${IOTEDGE_UID_AZIOTID}-g aziotid -c 'aziot-identityd user' -G aziotcs,aziotks,aziottpm -s /sbin/nologin -d ${localstatedir}/lib/aziot/identityd aziotid; "
 # Add aziottpm to tss group for TPM device access
 # Fixes: https://github.com/Azure/meta-iotedge/issues/132
-USERADD_PARAM:${PN} += "-r -u 13627 -g aziottpm -G tss -c 'aziot-tpmd user' -s /sbin/nologin -d ${localstatedir}/lib/aziot/tpmd aziottpm; "
+USERADD_PARAM:${PN} += "-r ${IOTEDGE_UID_AZIOTTPM}-g aziottpm -G tss -c 'aziot-tpmd user' -s /sbin/nologin -d ${localstatedir}/lib/aziot/tpmd aziottpm; "
 
-GROUPADD_PARAM:${PN} = "-r -g 13624 aziotcs; "
-GROUPADD_PARAM:${PN} += "-r -g 13625 aziotks; "
-GROUPADD_PARAM:${PN} += "-r -g 13626 aziotid; "
-GROUPADD_PARAM:${PN} += "-r -g 13627 aziottpm; "
+# Group GIDs are static only when IOTEDGE_STATIC_UIDS = "1".
+IOTEDGE_GID_AZIOTCS = "${@'-g 13624 ' if d.getVar('IOTEDGE_STATIC_UIDS') == '1' else ''}"
+IOTEDGE_GID_AZIOTKS = "${@'-g 13625 ' if d.getVar('IOTEDGE_STATIC_UIDS') == '1' else ''}"
+IOTEDGE_GID_AZIOTID = "${@'-g 13626 ' if d.getVar('IOTEDGE_STATIC_UIDS') == '1' else ''}"
+IOTEDGE_GID_AZIOTTPM = "${@'-g 13627 ' if d.getVar('IOTEDGE_STATIC_UIDS') == '1' else ''}"
+GROUPADD_PARAM:${PN} = "-r ${IOTEDGE_GID_AZIOTCS}aziotcs; "
+GROUPADD_PARAM:${PN} += "-r ${IOTEDGE_GID_AZIOTKS}aziotks; "
+GROUPADD_PARAM:${PN} += "-r ${IOTEDGE_GID_AZIOTID}aziotid; "
+GROUPADD_PARAM:${PN} += "-r ${IOTEDGE_GID_AZIOTTPM}aziottpm; "
 
 export SOCKET_DIR = "/run/aziot"
 export USER_AZIOTID = "aziotid"

--- a/recipes-core/aziotd/aziotd.inc
+++ b/recipes-core/aziotd/aziotd.inc
@@ -110,10 +110,11 @@ inherit useradd
 USERADD_PACKAGES = "${PN}"
 
 # Optionally pin the aziot service users/groups to static UIDs/GIDs.
-# Opt-in and defaults off (legacy dynamic allocation). See aziot-edged.inc and
-# https://github.com/Azure/meta-iotedge/issues/130 for the rationale and the
-# A/B upgrade ownership caveat. Set IOTEDGE_STATIC_UIDS = "1" to enable.
-IOTEDGE_STATIC_UIDS ??= "0"
+# Version-dependent default (see aziot-edged.inc and issue #130): 1.6 (new LTS)
+# defaults ON so the one-time static-ID move lands with the major upgrade; 1.5.x
+# (shipped) stays OFF to avoid changing on-disk ownership for fielded devices.
+# Override with IOTEDGE_STATIC_UIDS in your distro or local.conf.
+IOTEDGE_STATIC_UIDS ??= "${@'1' if (d.getVar('PV') or '').startswith('1.6') else '0'}"
 IOTEDGE_UID_AZIOTCS = "${@'-u 13624 ' if d.getVar('IOTEDGE_STATIC_UIDS') == '1' else ''}"
 IOTEDGE_UID_AZIOTKS = "${@'-u 13625 ' if d.getVar('IOTEDGE_STATIC_UIDS') == '1' else ''}"
 IOTEDGE_UID_AZIOTID = "${@'-u 13626 ' if d.getVar('IOTEDGE_STATIC_UIDS') == '1' else ''}"


### PR DESCRIPTION
## Summary

This PR makes the static IDs configurable via a new `IOTEDGE_STATIC_UIDS` flag and sets a **version-dependent default**, so the one-time ownership move lands on the version boundary where integrators are already re-testing, while fielded 1.5 devices see no change.

- New variable `IOTEDGE_STATIC_UIDS`, defaulted per IoT Edge version (`PV`):
  - **1.6** (new LTS line) defaults to `"1"` (static): `iotedge` (13620), `aziotcs` (13624), `aziotks` (13625), `aziotid` (13626), `aziottpm` (13627) and matching GIDs are pinned. The deterministic numbering is in place from the start of the line.
  - **1.5.x** (already shipped) defaults to `"0"` (dynamic): identical allocation to the 1.5.35 release, so fielded devices see no on-disk ownership change.
  - Both lines coexist on the same branch; set `IOTEDGE_STATIC_UIDS = "1"` or `"0"` in your distro config or `local.conf` to override either default.
- `edgeagentuser` (13622) and `edgehubuser` (13623) were statically pinned **before** #196 and are always assigned; left unchanged to avoid a regression.
- The `docker` group stays dynamic (shared with other layers).

## Why a version-keyed default instead of pure opt-in

Static IDs are the strictly-better end state: dynamic allocation can shift the same IDs on any rebuild, while static IDs never drift once assigned. The only cost is a one-time on-disk ownership change. A new LTS line (1.6) is the right place to absorb that, since integrators are already validating the major upgrade. Forcing the change onto an already-shipped line (1.5.x) would re-own persisted data on live devices, so that line keeps the legacy dynamic default. A first-boot ownership-reconciliation service could make the dynamic->static hop automatic, but mutating persisted ownership needs validation on real A/B hardware (daemon ordering, idempotency) that isn't available here, so it's left out.

## Validation

`bitbake -e` in both modes (qemux86-64):

**1.5.x default / `IOTEDGE_STATIC_UIDS = "0"` (dynamic):**
```
USERADD_PARAM:aziot-edged="-r -g iotedge ... iotedge; ...edgeagentuser; ...edgehubuser;"
GROUPADD_PARAM:aziot-edged="-r iotedge; -r docker"
USERADD_PARAM:aziotd="-r -g aziotcs ...; -r -g aziotks ...; -r -g aziotid ...; -r -g aziottpm ...;"
```
(dynamic users, no `-u`, matches legacy 1.5.35)

**1.6 default / `IOTEDGE_STATIC_UIDS = "1"` (static):**
```
USERADD_PARAM:aziot-edged="-r -u 13620 -g iotedge ...;"
GROUPADD_PARAM:aziot-edged="-r -g 13620 iotedge; -r docker"
USERADD_PARAM:aziotd="-r -u 13624 ...; -r -u 13625 ...; -r -u 13626 ...; -r -u 13627 ...;"
GROUPADD_PARAM:aziotd="-r -g 13624 aziotcs; -r -g 13625 aziotks; -r -g 13626 aziotid; -r -g 13627 aziottpm;"
```
(static IDs, matches pre-flag main)

No parse errors in either mode.

Refs #130