### PR TITLE
Release 1.5 and 1.6 as parallel Yocto lines

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,12 @@ jobs:
     needs: build
     runs-on: ubuntu-22.04
     steps:
+      - name: Check out release tag and history
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
+          fetch-depth: 0
+
       - name: Download RPM packages
         uses: actions/download-artifact@v8
         with:
@@ -75,51 +81,142 @@ jobs:
           
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
+      - name: Prepare release metadata and notes
+        id: metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          VERSION="${{ steps.artifacts.outputs.version }}"
+          case "$VERSION" in
+            1.5.*)
+              SERIES="1.5"
+              YOCTO="Scarthgap"
+              TEMPLATE="scarthgap"
+              RELEASE_SUMMARY="This is a maintenance release for the **Scarthgap (Yocto 5.0) / IoT Edge 1.5.x** line. It is not a downgrade from a 1.6.x release."
+              ;;
+            1.6.*)
+              SERIES="1.6"
+              YOCTO="Wrynose"
+              TEMPLATE="wrynose"
+              RELEASE_SUMMARY="This release belongs to the **Wrynose (Yocto 6.0) / IoT Edge 1.6.x** line."
+              ;;
+            *)
+              echo "Unsupported release tag: $VERSION" >&2
+              exit 1
+              ;;
+          esac
+
+          if [[ "$VERSION" == *-rc* || "$VERSION" == *-beta* ]]; then
+            PRERELEASE=true
+          else
+            PRERELEASE=false
+          fi
+
+          # GitHub otherwise compares generated notes against the most recently
+          # published release, which may be from the other supported release line.
+          PREVIOUS_TAG="$(git tag --list "${SERIES}.*" --sort=-version:refname \
+            | grep -Fxv "$VERSION" \
+            | head -n 1 || true)"
+
+          # Before 1.6 GA, 1.5 remains the latest stable line. After 1.6 GA,
+          # later 1.5 maintenance releases must not move Latest back to 1.5.
+          HAS_STABLE_16="$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+            --jq 'any(.[]; .draft == false and .prerelease == false and (.tag_name | startswith("1.6.")))')"
+          if [[ "$SERIES" == "1.6" && "$PRERELEASE" == "false" ]]; then
+            HAS_STABLE_16=true
+          fi
+
+          if [[ "$PRERELEASE" == "true" ]]; then
+            MAKE_LATEST=false
+          elif [[ "$SERIES" == "1.6" ]]; then
+            MAKE_LATEST=true
+          elif [[ "$HAS_STABLE_16" == "true" ]]; then
+            MAKE_LATEST=false
+          else
+            MAKE_LATEST=true
+          fi
+
+          {
+            echo "series=$SERIES"
+            echo "yocto=$YOCTO"
+            echo "template=$TEMPLATE"
+            echo "prerelease=$PRERELEASE"
+            echo "previous_tag=$PREVIOUS_TAG"
+            echo "make_latest=$MAKE_LATEST"
+          } >> "$GITHUB_OUTPUT"
+
+          if [[ "$HAS_STABLE_16" == "true" ]]; then
+            WRYNOSE_STATUS="Active and maintained"
+          else
+            WRYNOSE_STATUS="Active; latest release is a prerelease"
+          fi
+
+          cat > release-notes.md <<EOF
+          ## ${YOCTO} release for IoT Edge ${SERIES}.x
+
+          ${RELEASE_SUMMARY}
+
+          The repository maintains two release lines side by side:
+
+          | Yocto release | IoT Edge line | Status |
+          | --- | --- | --- |
+          | Scarthgap (5.0) | 1.5.x | Active and supported through November 2026 |
+          | Wrynose (6.0) | 1.6.x | ${WRYNOSE_STATUS} |
+
+          Release tags can alternate between 1.5.x and 1.6.x. Choose the tag that matches your Yocto release.
+
+          ## Build from source
+
+          Most users should build from source using the recipes in this repository. The prebuilt RPMs below target \`qemux86-64\` and will not work on other hardware.
+
+          \`\`\`bash
+          git clone --branch ${VERSION} https://github.com/${GITHUB_REPOSITORY}.git
+          cd meta-iotedge
+          ./scripts/build.sh ${TEMPLATE}
+          \`\`\`
+
+          ## Prebuilt artifacts (qemux86-64 only)
+
+          These artifacts are primarily for CI verification and testing.
+
+          ### RPM packages
+
+          \`\`\`bash
+          tar -xzvf iotedge-rpms-${VERSION}.tar.gz
+          \`\`\`
+
+          Included: iotedge, aziot-edged, aziotd, aziotctl, aziot-keys.
+
+          ### QEMU test image
+
+          \`\`\`bash
+          zstd -d iotedge-qemu-image-qemux86-64.rootfs.ext4.zst
+
+          qemu-system-x86_64 \\
+            -kernel bzImage \\
+            -drive file=iotedge-qemu-image-qemux86-64.rootfs.ext4,format=raw \\
+            -append "root=/dev/sda console=ttyS0" \\
+            -nographic -m 512
+          \`\`\`
+
+          ## Documentation
+
+          See the [README](https://github.com/${GITHUB_REPOSITORY}#readme) for build and integration instructions.
+
+          > **Repository history note:** \`main\` contains both the Scarthgap/1.5.x and Wrynose/1.6.x recipes. Generated notes compare against the previous ${SERIES}.x tag, but the repository diff may still include changes for both release lines.
+          EOF
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.tag || github.ref_name }}
-          name: IoT Edge Yocto Layer ${{ steps.artifacts.outputs.version }}
+          name: IoT Edge Yocto Layer ${{ steps.artifacts.outputs.version }} (${{ steps.metadata.outputs.yocto }} / ${{ steps.metadata.outputs.series }}.x)
           draft: false
-          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') }}
+          prerelease: ${{ steps.metadata.outputs.prerelease }}
+          make_latest: ${{ steps.metadata.outputs.make_latest }}
           generate_release_notes: true
+          previous_tag: ${{ steps.metadata.outputs.previous_tag }}
           files: final-artifacts/*
-          body: |
-            ## Azure IoT Edge Yocto Layer Release
-            
-            This release provides Yocto/OpenEmbedded recipes for building Azure IoT Edge on embedded Linux systems.
-            
-            ### For Yocto Users
-            
-            **Most users should build from source using the recipes in this repository.** The pre-built RPMs below are for the `qemux86-64` target and won't work on other hardware. To build for your target:
-            
-            ```bash
-            git clone --branch ${{ steps.artifacts.outputs.version }} https://github.com/${{ github.repository }}.git
-            cd meta-iotedge
-            ./scripts/build.sh ${{ needs.build.outputs.template }}
-            ```
-            
-            ### Pre-built Artifacts (qemux86-64 only)
-            
-            These artifacts are primarily for CI verification and testing:
-            
-            **RPM Packages** — Built for `qemux86-64`, useful for reference:
-            ```bash
-            tar -xzvf iotedge-rpms-${{ steps.artifacts.outputs.version }}.tar.gz
-            ```
-            
-            Included: iotedge, aziot-edged, aziotd, aziotctl, aziot-keys
-            
-            **QEMU Test Image** — Complete bootable image with IoT Edge pre-installed:
-            ```bash
-            zstd -d iotedge-qemu-image-qemux86-64.rootfs.ext4.zst
-            
-            qemu-system-x86_64 \
-              -kernel bzImage \
-              -drive file=iotedge-qemu-image-qemux86-64.rootfs.ext4,format=raw \
-              -append "root=/dev/sda console=ttyS0" \
-              -nographic -m 512
-            ```
-            
-            ### Documentation
-            See the [README](https://github.com/${{ github.repository }}#readme) for detailed build and integration instructions.
+          body_path: release-notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,16 @@ jobs:
 
           # GitHub otherwise compares generated notes against the most recently
           # published release, which may be from the other supported release line.
-          PREVIOUS_TAG="$(git tag --list "${SERIES}.*" --sort=-version:refname \
+          # Configure Git's version sort so prereleases sort before their stable
+          # release, while numeric Yocto-layer revisions sort after it:
+          # beta < rc < stable < -1 < -2. Limit candidates to ancestors of the
+          # checked-out tag so manually rerunning an older release can't select
+          # a newer tag as its comparison base.
+          PREVIOUS_TAG="$(git \
+            -c versionsort.suffix=-beta \
+            -c versionsort.suffix=-rc \
+            -c versionsort.suffix= \
+            tag --list "${SERIES}.*" --merged=HEAD --sort=-version:refname \
             | grep -Fxv "$VERSION" \
             | head -n 1 || true)"
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,7 +1,9 @@
 # Yocto + IoT Edge Release Guide
 
-This guide covers the IoT Edge release process for Yocto Scarthgap (main branch). Kirkstone uses templates on main
-and does not have a dedicated branch or CI runs.
+This guide covers the parallel IoT Edge release process on `main`:
+IoT Edge 1.5.x for Yocto Scarthgap and IoT Edge 1.6.x for Yocto Wrynose.
+Kirkstone uses templates on `main` and does not have a dedicated branch or CI
+runs.
 
 ## Release Flow
 
@@ -46,13 +48,17 @@ flowchart TD
 
    ```bash
    git pull origin main
-   git tag 1.5.35
-   git push origin 1.5.35
+   git tag 1.5.35                 # Scarthgap / IoT Edge 1.5.x
+   # or
+   git tag 1.6.0                  # Wrynose / IoT Edge 1.6.x
+   git push origin <tag>
    ```
 
-   > **Note:** The tag matches the upstream release (e.g., `1.5.35`) even if the recipe
-   > filenames use the daemon version (e.g., `1.5.21`). The `.inc` file stores
-   > `IOTEDGE_RELEASE = "1.5.35"` for traceability.
+   > **Note:** The tag matches the upstream release (for example, `1.5.35`)
+   > even if the recipe filenames use the daemon version (for example,
+   > `1.5.21`). The `.inc` file stores `IOTEDGE_RELEASE = "1.5.35"` for
+   > traceability. A suffix such as `-1` identifies a Yocto-layer maintenance
+   > revision without inventing a new upstream IoT Edge product version.
 
 5. **Verify** — Check [GitHub Releases](https://github.com/Azure/meta-iotedge/releases)
 
@@ -92,11 +98,34 @@ The workflow uses `scripts/check-upstream.sh` to fetch `product-versions.json` a
 - Old recipes are automatically removed when updating to a new version
 - Git tags preserve history — checkout a tag to get old recipes: `git checkout 1.5.5`
 
+## Parallel Release Lines
+
+`main` carries two active recipe lines at the same time. Tags can alternate
+chronologically; they are not a single monotonically increasing product stream.
+
+|Tag series|Yocto release|Template|Release title|
+|---|---|---|---|
+|`1.5.*`|Scarthgap (5.0 LTS)|`scarthgap`|Scarthgap / IoT Edge 1.5.x|
+|`1.6.*`|Wrynose (6.0 LTS)|`wrynose`|Wrynose / IoT Edge 1.6.x|
+
+Release automation compares generated notes with the previous tag in the same
+series. Release notes identify both the Yocto release and IoT Edge line so a
+later 1.5 maintenance release is not mistaken for a downgrade from 1.6.
+
+The GitHub **Latest** marker follows the latest stable product generation:
+
+- Before 1.6 GA, a stable 1.5 release remains Latest and 1.6 prereleases do not
+  replace it.
+- A stable 1.6 release becomes Latest.
+- After 1.6 GA, later 1.5 maintenance releases remain supported releases but do
+  not move Latest back to 1.5.
+
 ## Branch Mapping
 
 | Branch | Yocto Release | Script Parameter |
 | ------ | ------------- | ---------------- |
 | main   | Scarthgap (5.0 LTS) | `scarthgap` |
+| main   | Wrynose (6.0 LTS) | `wrynose` |
 | main (templates only) | Kirkstone (out of support Apr'2026) | `kirkstone` |
 
 ## Manual Recipe Updates


### PR DESCRIPTION
## Summary

`main` now carries two active release lines, but the release workflow still treated GitHub Releases as one chronological version stream. That made the new `1.5.35-1` Scarthgap maintenance release compare against `1.6.0-rc.1` and read like a downgrade.

This PR makes the release line explicit and keeps future 1.5/1.6 releases independent:

- Titles releases with the matching Yocto and IoT Edge line.
- Generates notes from the previous tag in the same series (`1.5.*` or `1.6.*`).
- Includes the parallel release-line table and template-specific build command.
- Keeps 1.5 as Latest until 1.6 GA.
- Makes stable 1.6 releases Latest.
- Prevents later 1.5 maintenance releases from moving Latest back to 1.5 after 1.6 GA.
- Fixes prerelease detection for manual workflow runs by using the requested tag instead of `github.ref_name`.
- Updates the release guide for both active lines.

The already-published `1.5.35-1` notes were corrected separately. This change prevents recurrence.

## Validation

- Parsed `.github/workflows/release.yml` with PyYAML.
- `bash -n` passed on the extracted metadata step.
- Executed metadata generation locally for:
  - `1.5.35-1` → previous `1.5.35`, stable, Latest (no stable 1.6 exists).
  - `1.6.0-rc.1` → prerelease, not Latest.
  - simulated `1.6.0` → previous `1.6.0-rc.1`, stable, Latest.
- `git diff --check` passed.
- Markdown lint has no net-new violations (23 after vs. 24 on `origin/main`; remaining findings predate this PR).
