### PR TITLE
Add scarthgap-1.6: build IoT Edge 1.6 on Yocto 5.0 (Scarthgap)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -101,8 +101,17 @@ jobs:
           # Tag-triggered builds (releases) pick the Yocto template from the
           # IoT Edge version: 1.6.x -> Wrynose, 1.5.x -> Scarthgap. Branch
           # builds map kirkstone -> kirkstone, everything else -> scarthgap.
+          #
+          # Scarthgap-1.6 override: IoT Edge 1.6 also builds on Yocto 5.0
+          # (Scarthgap) via the scarthgap-1.6 template, for customers who need
+          # 1.6 before they can move to Wrynose (6.0). Because that shares the
+          # 1.6.x version with the Wrynose line, a bare 1.6.x tag can't
+          # disambiguate it. A release tag with the '-scarthgap' suffix
+          # (e.g. 1.6.0-scarthgap, 1.6.1-scarthgap) selects the scarthgap-1.6
+          # template; a plain 1.6.x tag stays Wrynose.
           REF="${{ inputs.ref || github.base_ref || github.ref_name }}"
           case "$REF" in
+            *-scarthgap|*-scarthgap.*) echo "template=scarthgap-1.6" >> "$GITHUB_OUTPUT" ;;
             1.6.*) echo "template=wrynose" >> "$GITHUB_OUTPUT" ;;
             1.5.*) echo "template=scarthgap" >> "$GITHUB_OUTPUT" ;;
             kirkstone) echo "template=kirkstone" >> "$GITHUB_OUTPUT" ;;
@@ -118,14 +127,17 @@ jobs:
           # Release tags (release.yml passes inputs.ref = 1.5.* / 1.6.*) build
           # ONLY that line's template, so we don't double-build a release or
           # build the wrong line (e.g. wrynose for a 1.5 tag). PR and push
-          # builds, which is where recipe changes land, build BOTH LTS lines
-          # (scarthgap = 1.5, wrynose = 1.6) so a passing check means both
-          # lines fetch, build, and boot. kirkstone is intentionally left out
+          # builds, which is where recipe changes land, build ALL LTS lines
+          # (scarthgap = 1.5, wrynose = 1.6, scarthgap-1.6 = 1.6-on-Yocto-5.0)
+          # so a passing check means every shipped line fetches, builds, and
+          # boots. kirkstone is intentionally left out
           # of the PR matrix: it shares the 1.5 recipe with scarthgap, so a
           # third leg adds cost without testing a distinct recipe shape.
           #
           # A tag is detected from inputs.ref (workflow_call from release.yml)
-          # or github.ref_type. Branch/PR events fall through to both lines.
+          # or github.ref_type. Branch/PR events fall through to all lines.
+          # A '-scarthgap'-suffixed 1.6 tag (e.g. 1.6.0-scarthgap) is also a
+          # release tag and collapses to the single scarthgap-1.6 template.
           REF="${{ inputs.ref || github.ref_name }}"
           IS_TAG="false"
           if [ "${{ github.ref_type }}" = "tag" ]; then
@@ -139,8 +151,8 @@ jobs:
             # Single template, matching the release line.
             templates="[\"${{ steps.set-template.outputs.template }}\"]"
           else
-            # Double-build both LTS lines on PR/push.
-            templates='["scarthgap","wrynose"]'
+            # Multi-build every LTS line on PR/push.
+            templates='["scarthgap","wrynose","scarthgap-1.6"]'
           fi
           echo "templates=${templates}" >> "$GITHUB_OUTPUT"
           echo "Build matrix templates: ${templates}"
@@ -204,9 +216,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # PR/push builds both LTS lines (scarthgap = 1.5, wrynose = 1.6);
-        # release tags collapse to the single matching template. See the
-        # set-matrix step in check-changes.
+        # PR/push builds every LTS line (scarthgap = 1.5, wrynose = 1.6,
+        # scarthgap-1.6 = 1.6-on-Yocto-5.0); release tags collapse to the
+        # single matching template. See the set-matrix step in check-changes.
         template: ${{ fromJSON(needs.check-changes.outputs.templates) }}
     runs-on:
     - self-hosted
@@ -305,8 +317,9 @@ jobs:
       - name: Determine overall status
         run: |
           # needs.build.result is the AGGREGATE of every matrix leg: GitHub
-          # reports 'success' only when ALL legs (scarthgap and wrynose on a
-          # PR/push) succeed, and 'failure' if any single leg fails. So this
+          # reports 'success' only when ALL legs (scarthgap, wrynose, and
+          # scarthgap-1.6 on a PR/push) succeed, and 'failure' if any single
+          # leg fails. So this
           # check fails the moment one line fails to build or boot, which is
           # what makes the green check honest across both LTS lines.
           if [ "${{ needs.check-changes.outputs.docs_only }}" == "true" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,17 @@ jobs:
               TEMPLATE="scarthgap"
               RELEASE_SUMMARY="This is a maintenance release for the **Scarthgap (Yocto 5.0) / IoT Edge 1.5.x** line. It is not a downgrade from a 1.6.x release."
               ;;
+            1.6.*-scarthgap|1.6.*-scarthgap.*)
+              # IoT Edge 1.6 built on Yocto 5.0 (Scarthgap) via the
+              # scarthgap-1.6 template + meta-lts-mixins Rust, for customers who
+              # need 1.6 before they can move to Wrynose (6.0). Shares the 1.6.x
+              # daemon/recipes with the Wrynose line; the '-scarthgap' tag
+              # suffix is what selects this Yocto line.
+              SERIES="1.6"
+              YOCTO="Scarthgap"
+              TEMPLATE="scarthgap-1.6"
+              RELEASE_SUMMARY="This release delivers **IoT Edge 1.6.x on Yocto 5.0 (Scarthgap)**, for devices that need 1.6 before moving to Wrynose (Yocto 6.0). It uses the same 1.6.x daemon as the Wrynose line."
+              ;;
             1.6.*)
               SERIES="1.6"
               YOCTO="Wrynose"
@@ -114,30 +125,62 @@ jobs:
             PRERELEASE=false
           fi
 
+          # Distinguish the secondary Scarthgap-1.6 line from the primary
+          # Wrynose 1.6 line. Both are SERIES=1.6, but Scarthgap-1.6 is a
+          # compatibility line: it must never take the "Latest" badge from the
+          # primary Wrynose release, and its release notes / previous-tag
+          # comparison must stay within its own '-scarthgap'-suffixed tags.
+          if [[ "$TEMPLATE" == "scarthgap-1.6" ]]; then
+            IS_SCARTHGAP_16=true
+          else
+            IS_SCARTHGAP_16=false
+          fi
+
           # GitHub otherwise compares generated notes against the most recently
           # published release, which may be from the other supported release line.
           # Configure Git's version sort so prereleases sort before their stable
           # release, while numeric Yocto-layer revisions sort after it:
           # beta < rc < stable < -1 < -2. Limit candidates to ancestors of the
           # checked-out tag so manually rerunning an older release can't select
-          # a newer tag as its comparison base.
+          # a newer tag as its comparison base. Scope the tag glob to the Yocto
+          # line so a Wrynose 1.6 release does not compare against a Scarthgap-1.6
+          # tag (or vice versa): Scarthgap-1.6 uses '1.6.*-scarthgap*', Wrynose
+          # 1.6 uses '1.6.*' with the '-scarthgap' tags filtered out.
+          if [[ "$IS_SCARTHGAP_16" == "true" ]]; then
+            TAG_GLOB="1.6.*-scarthgap*"
+            TAG_FILTER="cat"
+          elif [[ "$SERIES" == "1.6" ]]; then
+            TAG_GLOB="1.6.*"
+            TAG_FILTER="grep -v -- -scarthgap"
+          else
+            TAG_GLOB="${SERIES}.*"
+            TAG_FILTER="cat"
+          fi
           PREVIOUS_TAG="$(git \
             -c versionsort.suffix=-beta \
             -c versionsort.suffix=-rc \
             -c versionsort.suffix= \
-            tag --list "${SERIES}.*" --merged=HEAD --sort=-version:refname \
+            tag --list "${TAG_GLOB}" --merged=HEAD --sort=-version:refname \
             | grep -Fxv "$VERSION" \
+            | ${TAG_FILTER} \
             | head -n 1 || true)"
 
           # Before 1.6 GA, 1.5 remains the latest stable line. After 1.6 GA,
           # later 1.5 maintenance releases must not move Latest back to 1.5.
+          # "1.6 GA" here means a Wrynose (primary-line) stable release, so the
+          # startswith check excludes '-scarthgap' compatibility tags.
           HAS_STABLE_16="$(gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
-            --jq 'any(.[]; .draft == false and .prerelease == false and (.tag_name | startswith("1.6.")))')"
-          if [[ "$SERIES" == "1.6" && "$PRERELEASE" == "false" ]]; then
+            --jq 'any(.[]; .draft == false and .prerelease == false and (.tag_name | startswith("1.6.")) and (.tag_name | contains("-scarthgap") | not))')"
+          if [[ "$SERIES" == "1.6" && "$PRERELEASE" == "false" && "$IS_SCARTHGAP_16" == "false" ]]; then
             HAS_STABLE_16=true
           fi
 
+          # Latest badge: only the primary Wrynose 1.6 stable line earns it.
+          # Scarthgap-1.6 is a compatibility line and is never Latest, so it
+          # can't override the Wrynose GA badge.
           if [[ "$PRERELEASE" == "true" ]]; then
+            MAKE_LATEST=false
+          elif [[ "$IS_SCARTHGAP_16" == "true" ]]; then
             MAKE_LATEST=false
           elif [[ "$SERIES" == "1.6" ]]; then
             MAKE_LATEST=true
@@ -167,14 +210,15 @@ jobs:
 
           ${RELEASE_SUMMARY}
 
-          The repository maintains two release lines side by side:
+          The repository maintains multiple release lines side by side:
 
           | Yocto release | IoT Edge line | Status |
           | --- | --- | --- |
           | Scarthgap (5.0) | 1.5.x | Active and supported through November 2026 |
           | Wrynose (6.0) | 1.6.x | ${WRYNOSE_STATUS} |
+          | Scarthgap (5.0) | 1.6.x (\`-scarthgap\` tags) | IoT Edge 1.6 on Yocto 5.0, for devices not yet on Wrynose |
 
-          Release tags can alternate between 1.5.x and 1.6.x. Choose the tag that matches your Yocto release.
+          Release tags select the line: \`1.5.x\` -> Scarthgap/1.5, \`1.6.x\` -> Wrynose/1.6, \`1.6.x-scarthgap\` -> Scarthgap/1.6. Choose the tag that matches your Yocto release.
 
           ## Build from source
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ Please see the corresponding sections below for details.
 Adding the meta-iotedge layer to your build
 =================================================
 
-Use the templates in `conf/templates/<release>` on the **main** branch for your Yocto release. The `main` branch supports two Yocto LTSes side by side, with the matching IoT Edge version selected by the template:
+Use the templates in `conf/templates/<release>` on the **main** branch for your Yocto release. The `main` branch supports multiple Yocto LTSes side by side, with the matching IoT Edge version selected by the template:
 
 **Active and maintained (main branch)**:
 * **Wrynose (Yocto 6.0)** - IoT Edge 1.6.x. `git clone -b main https://github.com/Azure/meta-iotedge.git`, then build with `./scripts/build.sh wrynose`.
 * **Scarthgap (Yocto 5.0)** - IoT Edge 1.5.x. `git clone -b main https://github.com/Azure/meta-iotedge.git`, then build with `./scripts/build.sh scarthgap`.
+* **Scarthgap (Yocto 5.0) with IoT Edge 1.6.x** - for devices that need 1.6 but cannot yet move to Wrynose (6.0). Build with `./scripts/build.sh scarthgap-1.6`. See [Scarthgap with IoT Edge 1.6](#scarthgap-with-iot-edge-16) below.
 
-The recipes for both IoT Edge versions live on `main` at the same time; each template pins the matching `PREFERRED_VERSION_*` so a Wrynose build produces 1.6.x and a Scarthgap build produces 1.5.x.
+The recipes for both IoT Edge versions live on `main` at the same time; each template pins the matching `PREFERRED_VERSION_*` so a Wrynose build produces 1.6.x and a Scarthgap build produces 1.5.x. The `scarthgap-1.6` template reuses the 1.6.x recipes on Scarthgap layers with a newer Rust toolchain (see below).
 
 **Kirkstone (out of support April 2026)**:
 * The `kirkstone` branch is frozen at IoT Edge 1.4.27 and will not receive further updates.
@@ -38,6 +39,7 @@ Branching Strategy and Timelines
 | :- | :- | :- | :- |
 | Wrynose | 1.6.x | main | Active and maintained |
 | Scarthgap | 1.5.x | main | Active and maintained |
+| Scarthgap | 1.6.x (`scarthgap-1.6` template) | main | Active and maintained |
 | Kirkstone | 1.5.x | main (templates only) | Out of Support Apr'2026 |
 | Kirkstone | 1.4.x | kirkstone (frozen) | Not active and Not maintained |
 | Dunfell | 1.4.x  | dunfell | Not active and Not maintained |
@@ -151,6 +153,24 @@ entirely in your `.bbappend` if you need full control. See [#181](https://github
 Kirkstone templates intentionally use `meta-rust` to provide Rust 1.78+ (Poky Kirkstone ships
 Rust 1.59, which is too old for IoT Edge 1.5). This is not required for Scarthgap. The `fetch.sh`
 script clones meta-rust automatically when targeting Kirkstone.
+
+Scarthgap with IoT Edge 1.6
+---------------------------
+
+The `scarthgap-1.6` template builds IoT Edge 1.6.x on Yocto 5.0 (Scarthgap) layers, for devices
+that need 1.6 before they can move to Wrynose (Yocto 6.0). It reuses the same 1.6.x recipes as the
+Wrynose line; only the Yocto layers and Rust toolchain differ.
+
+IoT Edge 1.6 needs a newer Rust than Poky Scarthgap ships (5.0 has 1.75). Rather than a local
+backport, `scarthgap-1.6` uses Yocto's official [`meta-lts-mixins`](https://git.yoctoproject.org/meta-lts-mixins)
+`scarthgap/rust` branch, which provides Rust 1.92.0 and is maintained through Scarthgap EOL
+(April 2028). 1.92 is sufficient for the entire 1.6 product: both `iot-identity-service` and the
+edgelet daemon compile cleanly with the `sysinfo` 0.38.4 pin the recipes already carry. The
+template masks Poky's `rust`/`cargo` so `meta-lts-mixins` provides the toolchain, mirroring the
+Kirkstone/meta-rust setup. `fetch.sh scarthgap-1.6` clones `meta-lts-mixins` automatically.
+
+Build with `./scripts/build.sh scarthgap-1.6`. Releases for this line use the `-scarthgap` tag
+suffix (for example `1.6.0-scarthgap`) so they are distinct from the Wrynose 1.6.x releases.
 
 
 Contributing

--- a/conf/templates/scarthgap-1.6/bblayers.conf.sample
+++ b/conf/templates/scarthgap-1.6/bblayers.conf.sample
@@ -1,0 +1,26 @@
+# LAYER_CONF_VERSION is increased each time build/conf/bblayers.conf
+# changes incompatibly
+LCONF_VERSION = "7"
+
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+
+BBLAYERS ?= " \
+  ##OEROOT##/meta-iotedge \
+  ##OEROOT##/meta \
+  ##OEROOT##/meta-poky \
+  ##OEROOT##/meta-yocto-bsp \
+  ##OEROOT##/meta-lts-mixins \
+  ##OEROOT##/meta-openembedded/meta-filesystems \
+  ##OEROOT##/meta-openembedded/meta-oe \
+  ##OEROOT##/meta-openembedded/meta-networking \
+  ##OEROOT##/meta-openembedded/meta-python \
+  ##OEROOT##/meta-virtualization \
+  ##OEROOT##/meta-security/meta-tpm \
+  ##OEROOT##/meta-clang \
+  "
+BBLAYERS_NON_REMOVABLE ?= " \
+  ##OEROOT##/meta \
+  ##OEROOT##/meta-yocto \
+  "
+

--- a/conf/templates/scarthgap-1.6/local.conf.sample
+++ b/conf/templates/scarthgap-1.6/local.conf.sample
@@ -207,7 +207,7 @@ PATCHRESOLVE = "noop"
 # shutdown the build. If there is less that 100MB or 1K inodes, perform a hard abort
 # of the build. The reason for this is that running completely out of space can corrupt
 # files and damages the build in ways which may not be easily recoverable.
-# It's necesary to monitor /tmp, if there is no space left the build will fail
+# It's necessary to monitor /tmp, if there is no space left the build will fail
 # with very exotic errors.
 BB_DISKMON_DIRS = "\
     STOPTASKS,${TMPDIR},1G,100K \

--- a/conf/templates/scarthgap-1.6/local.conf.sample
+++ b/conf/templates/scarthgap-1.6/local.conf.sample
@@ -1,0 +1,288 @@
+#
+# This file is your local configuration file and is where all local user settings
+# are placed. The comments in this file give some guide to the options a new user
+# to the system might want to change but pretty much any configuration option can
+# be set in this file. More adventurous users can look at local.conf.extended
+# which contains other examples of configuration which can be placed in this file
+# but new users likely won't need any of them initially.
+#
+# Lines starting with the '#' character are commented out and in some cases the
+# default values are provided as comments to show people example syntax. Enabling
+# the option is a question of removing the # character and making any change to the
+# variable as required.
+
+#
+# Machine Selection
+#
+# You need to select a specific machine to target the build with. There are a selection
+# of emulated machines available which can boot and run in the QEMU emulator:
+#
+#MACHINE ?= "qemuarm"
+#MACHINE ?= "qemuarm64"
+#MACHINE ?= "qemumips"
+#MACHINE ?= "qemumips64"
+#MACHINE ?= "qemuppc"
+#MACHINE ?= "qemux86"
+#MACHINE ?= "qemux86-64"
+#
+# There are also the following hardware board target machines included for 
+# demonstration purposes:
+#
+#MACHINE ?= "beaglebone"
+#MACHINE ?= "genericx86"
+#MACHINE ?= "genericx86-64"
+#MACHINE ?= "mpc8315e-rdb"
+#MACHINE ?= "edgerouter"
+#
+# This sets the default machine to be qemux86 if no other machine is selected:
+MACHINE ??= "qemux86-64"
+
+# Increase BitBake server timeout for slower container starts
+BB_SERVER_TIMEOUT = "600"
+
+#
+# Where to place downloads
+#
+# During a first build the system will download many different source code tarballs
+# from various upstream projects. This can take a while, particularly if your network
+# connection is slow. These are all stored in DL_DIR. When wiping and rebuilding you
+# can preserve this directory to speed up this part of subsequent builds. This directory
+# is safe to share between multiple builds on the same machine too.
+#
+# The default is a downloads directory under TOPDIR which is the build directory.
+#
+#DL_DIR ?= "${TOPDIR}/downloads"
+DL_DIR ?= "/workspaces/yocto-cache/downloads"
+
+# Fetch robustness (retries + per-try timeout). Increase if your network is flaky.
+BB_FETCH_RETRIES ?= "5"
+BB_FETCH_TIMEOUT ?= "60"
+
+#
+# Where to place shared-state files
+#
+# BitBake has the capability to accelerate builds based on previously built output.
+# This is done using "shared state" files which can be thought of as cache objects
+# and this option determines where those files are placed.
+#
+# You can wipe out TMPDIR leaving this directory intact and the build would regenerate
+# from these files if no changes were made to the configuration. If changes were made
+# to the configuration, only shared state files where the state was still valid would
+# be used (done using checksums).
+#
+# The default is a sstate-cache directory under TOPDIR.
+#
+#SSTATE_DIR ?= "${TOPDIR}/sstate-cache"
+SSTATE_DIR ?= "/workspaces/yocto-cache/sstate-cache"
+
+#
+# Where to place the build output
+#
+# This option specifies where the bulk of the building work should be done and
+# where BitBake should place its temporary files and output. Keep in mind that
+# this includes the extraction and compilation of many applications and the toolchain
+# which can use Gigabytes of hard disk space.
+#
+# The default is a tmp directory under TOPDIR.
+#
+#TMPDIR = "${TOPDIR}/tmp"
+
+# Scale parallelism to available CPU (override as needed)
+BB_NUMBER_THREADS ?= "${@oe.utils.cpu_count()}"
+PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
+
+# Remove work directories after packaging to save disk space (~50GB savings)
+# Exclude IoT Edge packages for debugging purposes
+INHERIT += "rm_work"
+RM_WORK_EXCLUDE += "iotedge aziot-edged aziotd aziotctl aziot-keys"
+
+#
+# Default policy config
+#
+# The distribution setting controls which policy settings are used as defaults.
+# The default value is fine for general Yocto project use, at least initially.
+# Ultimately when creating custom policy, people will likely end up subclassing 
+# these defaults.
+#
+DISTRO ?= "poky"
+# As an example of a subclass there is a "bleeding" edge policy configuration
+# where many versions are set to the absolute latest code from the upstream 
+# source control systems. This is just mentioned here as an example, its not
+# useful to most new users.
+# DISTRO ?= "poky-bleeding"
+
+#
+# Package Management configuration
+#
+# This variable lists which packaging formats to enable. Multiple package backends
+# can be enabled at once and the first item listed in the variable will be used
+# to generate the root filesystems.
+# Options are:
+#  - 'package_deb' for debian style deb files
+#  - 'package_ipk' for ipk files are used by opkg (a debian style embedded package manager)
+#  - 'package_rpm' for rpm style packages
+# E.g.: PACKAGE_CLASSES ?= "package_rpm package_deb package_ipk"
+# We default to rpm:
+PACKAGE_CLASSES ?= "package_rpm"
+
+#
+# SDK target architecture
+#
+# This variable specifies the architecture to build SDK items for and means
+# you can build the SDK packages for architectures other than the machine you are
+# running the build on (i.e. building i686 packages on an x86_64 host).
+# Supported values are i686 and x86_64
+#SDKMACHINE ?= "i686"
+
+#
+# Extra image configuration defaults
+#
+# The EXTRA_IMAGE_FEATURES variable allows extra packages to be added to the generated
+# images. Some of these options are added to certain image types automatically. The
+# variable can contain the following options:
+#  "dbg-pkgs"       - add -dbg packages for all installed packages
+#                     (adds symbol information for debugging/profiling)
+#  "dev-pkgs"       - add -dev packages for all installed packages
+#                     (useful if you want to develop against libs in the image)
+#  "ptest-pkgs"     - add -ptest packages for all ptest-enabled packages
+#                     (useful if you want to run the package test suites)
+#  "tools-sdk"      - add development tools (gcc, make, pkgconfig etc.)
+#  "tools-debug"    - add debugging tools (gdb, strace)
+#  "eclipse-debug"  - add Eclipse remote debugging support
+#  "tools-profile"  - add profiling tools (oprofile, lttng, valgrind)
+#  "tools-testapps" - add useful testing tools (ts_print, aplay, arecord etc.)
+#  "debug-tweaks"   - make an image suitable for development
+#                     e.g. ssh root access has a blank password
+# There are other application targets that can be used here too, see
+# meta/classes/image.bbclass and meta/classes/core-image.bbclass for more details.
+# We default to enabling the debugging tweaks.
+EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
+
+#
+# Additional image features
+#
+# The following is a list of additional classes to use when building images which
+# enable extra features. Some available options which can be included in this variable
+# are:
+#   - 'buildstats' collect build statistics
+#   - 'image-prelink' in order to prelink the filesystem image
+#   - 'image-swab' to perform host system intrusion detection
+# NOTE: if listing mklibs & prelink both, then make sure mklibs is before prelink
+# NOTE: mklibs also needs to be explicitly enabled for a given image, see local.conf.extended
+# image-prelink disabled for now due to issues with IFUNC symbol relocation
+USER_CLASSES ?= "buildstats"
+
+#
+# Runtime testing of images
+#
+# The build system can test booting virtual machine images under qemu (an emulator)
+# after any root filesystems are created and run tests against those images. To
+# enable this uncomment this line. See classes/testimage(-auto).bbclass for
+# further details.
+#TEST_IMAGE = "1"
+#
+# Interactive shell configuration
+#
+# Under certain circumstances the system may need input from you and to do this it
+# can launch an interactive shell. It needs to do this since the build is
+# multithreaded and needs to be able to handle the case where more than one parallel
+# process may require the user's attention. The default is iterate over the available
+# terminal types to find one that works.
+#
+# Examples of the occasions this may happen are when resolving patches which cannot
+# be applied, to use the devshell or the kernel menuconfig
+#
+# Supported values are auto, gnome, xfce, rxvt, screen, konsole (KDE 3.x only), none
+# Note: currently, Konsole support only works for KDE 3.x due to the way
+# newer Konsole versions behave
+#OE_TERMINAL = "auto"
+# By default disable interactive patch resolution (tasks will just fail instead):
+PATCHRESOLVE = "noop"
+
+#
+# Disk Space Monitoring during the build
+#
+# Monitor the disk space during the build. If there is less that 1GB of space or less
+# than 100K inodes in any key build location (TMPDIR, DL_DIR, SSTATE_DIR), gracefully
+# shutdown the build. If there is less that 100MB or 1K inodes, perform a hard abort
+# of the build. The reason for this is that running completely out of space can corrupt
+# files and damages the build in ways which may not be easily recoverable.
+# It's necesary to monitor /tmp, if there is no space left the build will fail
+# with very exotic errors.
+BB_DISKMON_DIRS = "\
+    STOPTASKS,${TMPDIR},1G,100K \
+    STOPTASKS,${DL_DIR},1G,100K \
+    STOPTASKS,${SSTATE_DIR},1G,100K \
+    STOPTASKS,/tmp,100M,100K \
+    HALT,${TMPDIR},100M,1K \
+    HALT,${DL_DIR},100M,1K \
+    HALT,${SSTATE_DIR},100M,1K \
+    HALT,/tmp,10M,1K"
+
+#
+# Shared-state files from other locations
+#
+# As mentioned above, shared state files are prebuilt cache data objects which can
+# used to accelerate build time. This variable can be used to configure the system
+# to search other mirror locations for these objects before it builds the data itself.
+#
+# This can be a filesystem directory, or a remote url such as http or ftp. These
+# would contain the sstate-cache results from previous builds (possibly from other
+# machines). This variable works like fetcher MIRRORS/PREMIRRORS and points to the
+# cache locations to check for the shared objects.
+# NOTE: if the mirror uses the same structure as SSTATE_DIR, you need to add PATH
+# at the end as shown in the examples below. This will be substituted with the
+# correct path within the directory structure.
+#SSTATE_MIRRORS ?= "\
+#file://.* http://someserver.tld/share/sstate/PATH;downloadfilename=PATH \n \
+#file://.* file:///some/local/dir/sstate/PATH"
+
+# Hash equivalence - enables sstate sharing across different build paths
+BB_SIGNATURE_HANDLER = "OEEquivHash"
+BB_HASHSERVE = "auto"
+SSTATE_MIRRORS ?= "file://.* https://sstate.yoctoproject.org/all/PATH;downloadfilename=PATH"
+
+#
+# Qemu configuration
+#
+# By default qemu will build with a builtin VNC server where graphical output can be
+# seen. The two lines below enable the SDL backend too. By default libsdl-native will
+# be built, if you want to use your host's libSDL instead of the minimal libsdl built
+# by libsdl-native then uncomment the ASSUME_PROVIDED line below.
+PACKAGECONFIG:append:pn-qemu-native = " sdl"
+PACKAGECONFIG:append:pn-nativesdk-qemu = " sdl"
+#ASSUME_PROVIDED += "libsdl-native"
+
+# CONF_VERSION is increased each time build/conf/ changes incompatibly and is used to
+# track the version of this file when it was generated. This can safely be ignored if
+# this doesn't mean anything to you.
+CONF_VERSION = "2"
+
+DISTRO_FEATURES:append = " systemd virtualization tpm2 usrmerge"
+VIRTUAL-RUNTIME_init_manager = "systemd"
+VIRTUAL-RUNTIME_initscripts = "systemd-compat-units"
+
+# --- Rust toolchain for IoT Edge 1.6 on Scarthgap (Yocto 5.0) ---
+# IoT Edge 1.6 needs a newer Rust than Poky Scarthgap ships (5.0 has Rust
+# 1.75). Yocto's official meta-lts-mixins scarthgap/rust layer provides
+# Rust 1.92.0, which is sufficient for the entire 1.6 product: both
+# iot-identity-service and the edgelet daemon compile clean on 1.92.0
+# (verified 2026-07 by cargo check at the 1.6.0 release SRCREVs, with the
+# existing sysinfo 0.38.4 pin the recipes already carry). So we mask Poky's
+# built-in rust/cargo and let meta-lts-mixins provide the toolchain, exactly
+# as the Kirkstone template does with meta-rust. No local Rust backport is
+# needed. meta-lts-mixins scarthgap/rust is maintained through Scarthgap EOL
+# (April 2028).
+BBMASK += "poky/meta/recipes-devtools/rust"
+BBMASK += "poky/meta/recipes-devtools/cargo"
+
+# --- IoT Edge version selection for Scarthgap + 1.6 (Yocto 5.0) ---
+# meta-iotedge carries coexisting recipe versions on a single branch. This
+# template pins the 1.6.x line onto Scarthgap (Yocto 5.0), for customers who
+# need 1.6 before they can move to Wrynose (Yocto 6.0). The stock `scarthgap`
+# template pins 1.5.x; `wrynose` pins 1.6.x on Yocto 6.0.
+PREFERRED_VERSION_iotedge = "1.6.0"
+PREFERRED_VERSION_aziot-edged = "1.6.0"
+PREFERRED_VERSION_aziotd = "1.6.0"
+PREFERRED_VERSION_aziotctl = "1.6.0"
+PREFERRED_VERSION_aziot-keys = "1.6.0"

--- a/recipes-core/aziot-edged/aziot-edged_1.6.0.bb
+++ b/recipes-core/aziot-edged/aziot-edged_1.6.0.bb
@@ -10,13 +10,13 @@ inherit cargo cargo-update-recipe-crates pkgconfig
 
 SRC_URI += "git://github.com/Azure/iotedge.git;protocol=https;nobranch=1"
 SRCREV = "314983eaa92809521518a95631a22d7a9259a3eb"
-CARGO_SRC_DIR = "edgelet"
 # Yocto release-agnostic source dir: mirror the git fetcher so ONE recipe is
 # correct on both Yocto lines that build it. git unpacks to
 # ${UNPACKDIR:-${WORKDIR}}/${BB_GIT_DEFAULT_DESTSUFFIX:-git}: Scarthgap (5.0)
 # leaves both unset -> ${WORKDIR}/git; Wrynose (6.0) sets them -> ${WORKDIR}/
 # sources/${BP}. A hardcoded /git breaks Wrynose; omitting S breaks Scarthgap.
 S = "${@(d.getVar('UNPACKDIR') or d.getVar('WORKDIR')) + '/' + (d.getVar('BB_GIT_DEFAULT_DESTSUFFIX') or 'git')}"
+CARGO_SRC_DIR = "edgelet"
 CARGO_BUILD_FLAGS += "-p aziot-edged"
 CARGO_LOCK_SRC_DIR = "${S}/edgelet"
 do_compile[network] = "1"

--- a/recipes-core/aziot-edged/aziot-edged_1.6.0.bb
+++ b/recipes-core/aziot-edged/aziot-edged_1.6.0.bb
@@ -11,6 +11,12 @@ inherit cargo cargo-update-recipe-crates pkgconfig
 SRC_URI += "git://github.com/Azure/iotedge.git;protocol=https;nobranch=1"
 SRCREV = "314983eaa92809521518a95631a22d7a9259a3eb"
 CARGO_SRC_DIR = "edgelet"
+# Yocto release-agnostic source dir: mirror the git fetcher so ONE recipe is
+# correct on both Yocto lines that build it. git unpacks to
+# ${UNPACKDIR:-${WORKDIR}}/${BB_GIT_DEFAULT_DESTSUFFIX:-git}: Scarthgap (5.0)
+# leaves both unset -> ${WORKDIR}/git; Wrynose (6.0) sets them -> ${WORKDIR}/
+# sources/${BP}. A hardcoded /git breaks Wrynose; omitting S breaks Scarthgap.
+S = "${@(d.getVar('UNPACKDIR') or d.getVar('WORKDIR')) + '/' + (d.getVar('BB_GIT_DEFAULT_DESTSUFFIX') or 'git')}"
 CARGO_BUILD_FLAGS += "-p aziot-edged"
 CARGO_LOCK_SRC_DIR = "${S}/edgelet"
 do_compile[network] = "1"

--- a/recipes-core/aziot-keys/aziot-keys_1.6.0.bb
+++ b/recipes-core/aziot-keys/aziot-keys_1.6.0.bb
@@ -16,13 +16,13 @@ CARGO_INSTALL_LIBRARIES = "1"
 
 SRC_URI += "gitsm://github.com/Azure/iot-identity-service.git;protocol=https;nobranch=1"
 SRCREV = "a6b1d1628be550ddda8cc65573e509c753b7cb65"
-CARGO_SRC_DIR = "key/aziot-keys"
 # Yocto release-agnostic source dir: mirror the git fetcher so ONE recipe is
 # correct on both Yocto lines that build it. git unpacks to
 # ${UNPACKDIR:-${WORKDIR}}/${BB_GIT_DEFAULT_DESTSUFFIX:-git}: Scarthgap (5.0)
 # leaves both unset -> ${WORKDIR}/git; Wrynose (6.0) sets them -> ${WORKDIR}/
 # sources/${BP}. A hardcoded /git breaks Wrynose; omitting S breaks Scarthgap.
 S = "${@(d.getVar('UNPACKDIR') or d.getVar('WORKDIR')) + '/' + (d.getVar('BB_GIT_DEFAULT_DESTSUFFIX') or 'git')}"
+CARGO_SRC_DIR = "key/aziot-keys"
 
 require ${BPN}-${PV}-crates.inc
 

--- a/recipes-core/aziot-keys/aziot-keys_1.6.0.bb
+++ b/recipes-core/aziot-keys/aziot-keys_1.6.0.bb
@@ -17,6 +17,12 @@ CARGO_INSTALL_LIBRARIES = "1"
 SRC_URI += "gitsm://github.com/Azure/iot-identity-service.git;protocol=https;nobranch=1"
 SRCREV = "a6b1d1628be550ddda8cc65573e509c753b7cb65"
 CARGO_SRC_DIR = "key/aziot-keys"
+# Yocto release-agnostic source dir: mirror the git fetcher so ONE recipe is
+# correct on both Yocto lines that build it. git unpacks to
+# ${UNPACKDIR:-${WORKDIR}}/${BB_GIT_DEFAULT_DESTSUFFIX:-git}: Scarthgap (5.0)
+# leaves both unset -> ${WORKDIR}/git; Wrynose (6.0) sets them -> ${WORKDIR}/
+# sources/${BP}. A hardcoded /git breaks Wrynose; omitting S breaks Scarthgap.
+S = "${@(d.getVar('UNPACKDIR') or d.getVar('WORKDIR')) + '/' + (d.getVar('BB_GIT_DEFAULT_DESTSUFFIX') or 'git')}"
 
 require ${BPN}-${PV}-crates.inc
 

--- a/recipes-core/aziotctl/aziotctl_1.6.0.bb
+++ b/recipes-core/aziotctl/aziotctl_1.6.0.bb
@@ -9,13 +9,13 @@ inherit cargo cargo-update-recipe-crates
 
 SRC_URI += "gitsm://github.com/Azure/iot-identity-service.git;protocol=https;nobranch=1"
 SRCREV = "a6b1d1628be550ddda8cc65573e509c753b7cb65"
-CARGO_SRC_DIR = "aziotctl"
 # Yocto release-agnostic source dir: mirror the git fetcher so ONE recipe is
 # correct on both Yocto lines that build it. git unpacks to
 # ${UNPACKDIR:-${WORKDIR}}/${BB_GIT_DEFAULT_DESTSUFFIX:-git}: Scarthgap (5.0)
 # leaves both unset -> ${WORKDIR}/git; Wrynose (6.0) sets them -> ${WORKDIR}/
 # sources/${BP}. A hardcoded /git breaks Wrynose; omitting S breaks Scarthgap.
 S = "${@(d.getVar('UNPACKDIR') or d.getVar('WORKDIR')) + '/' + (d.getVar('BB_GIT_DEFAULT_DESTSUFFIX') or 'git')}"
+CARGO_SRC_DIR = "aziotctl"
 
 require ${BPN}-${PV}-crates.inc
 

--- a/recipes-core/aziotctl/aziotctl_1.6.0.bb
+++ b/recipes-core/aziotctl/aziotctl_1.6.0.bb
@@ -10,6 +10,12 @@ inherit cargo cargo-update-recipe-crates
 SRC_URI += "gitsm://github.com/Azure/iot-identity-service.git;protocol=https;nobranch=1"
 SRCREV = "a6b1d1628be550ddda8cc65573e509c753b7cb65"
 CARGO_SRC_DIR = "aziotctl"
+# Yocto release-agnostic source dir: mirror the git fetcher so ONE recipe is
+# correct on both Yocto lines that build it. git unpacks to
+# ${UNPACKDIR:-${WORKDIR}}/${BB_GIT_DEFAULT_DESTSUFFIX:-git}: Scarthgap (5.0)
+# leaves both unset -> ${WORKDIR}/git; Wrynose (6.0) sets them -> ${WORKDIR}/
+# sources/${BP}. A hardcoded /git breaks Wrynose; omitting S breaks Scarthgap.
+S = "${@(d.getVar('UNPACKDIR') or d.getVar('WORKDIR')) + '/' + (d.getVar('BB_GIT_DEFAULT_DESTSUFFIX') or 'git')}"
 
 require ${BPN}-${PV}-crates.inc
 

--- a/recipes-core/aziotd/aziotd_1.6.0.bb
+++ b/recipes-core/aziotd/aziotd_1.6.0.bb
@@ -10,6 +10,12 @@ inherit cargo cargo-update-recipe-crates pkgconfig
 SRC_URI += "gitsm://github.com/Azure/iot-identity-service.git;protocol=https;nobranch=1"
 SRCREV = "a6b1d1628be550ddda8cc65573e509c753b7cb65"
 CARGO_SRC_DIR = "aziotd"
+# Yocto release-agnostic source dir: mirror the git fetcher so ONE recipe is
+# correct on both Yocto lines that build it. git unpacks to
+# ${UNPACKDIR:-${WORKDIR}}/${BB_GIT_DEFAULT_DESTSUFFIX:-git}: Scarthgap (5.0)
+# leaves both unset -> ${WORKDIR}/git; Wrynose (6.0) sets them -> ${WORKDIR}/
+# sources/${BP}. A hardcoded /git breaks Wrynose; omitting S breaks Scarthgap.
+S = "${@(d.getVar('UNPACKDIR') or d.getVar('WORKDIR')) + '/' + (d.getVar('BB_GIT_DEFAULT_DESTSUFFIX') or 'git')}"
 
 require ${BPN}-${PV}-crates.inc
 

--- a/recipes-core/aziotd/aziotd_1.6.0.bb
+++ b/recipes-core/aziotd/aziotd_1.6.0.bb
@@ -9,13 +9,13 @@ inherit cargo cargo-update-recipe-crates pkgconfig
 
 SRC_URI += "gitsm://github.com/Azure/iot-identity-service.git;protocol=https;nobranch=1"
 SRCREV = "a6b1d1628be550ddda8cc65573e509c753b7cb65"
-CARGO_SRC_DIR = "aziotd"
 # Yocto release-agnostic source dir: mirror the git fetcher so ONE recipe is
 # correct on both Yocto lines that build it. git unpacks to
 # ${UNPACKDIR:-${WORKDIR}}/${BB_GIT_DEFAULT_DESTSUFFIX:-git}: Scarthgap (5.0)
 # leaves both unset -> ${WORKDIR}/git; Wrynose (6.0) sets them -> ${WORKDIR}/
 # sources/${BP}. A hardcoded /git breaks Wrynose; omitting S breaks Scarthgap.
 S = "${@(d.getVar('UNPACKDIR') or d.getVar('WORKDIR')) + '/' + (d.getVar('BB_GIT_DEFAULT_DESTSUFFIX') or 'git')}"
+CARGO_SRC_DIR = "aziotd"
 
 require ${BPN}-${PV}-crates.inc
 

--- a/recipes-core/iot-identity-service.inc
+++ b/recipes-core/iot-identity-service.inc
@@ -249,8 +249,15 @@ too_many_lines = "allow"
 type_complexity = "allow"
 '''
 
-    unpackdir = d.getVar('UNPACKDIR')
-    if not unpackdir:
+    # UNPACK_ROOT resolves to UNPACKDIR on Wrynose (6.0) and falls back to
+    # WORKDIR on Scarthgap (5.0) -- exactly where the crates were unpacked and
+    # where EXTRA_OECARGO_PATHS point. The synthetic root must live at that
+    # common parent on BOTH releases. (Previously this bailed when UNPACKDIR
+    # was unset, so Scarthgap never got a root and the edgelet's
+    # path-redirected cert/*-async crates could not inherit
+    # workspace.dependencies.hyper -> "failed to find a workspace root".)
+    unpack_root = d.getVar('UNPACK_ROOT') or d.getVar('WORKDIR')
+    if not unpack_root:
         return
 
     # Derive workspace members from the IIS crates we actually fetched, using
@@ -269,7 +276,7 @@ type_complexity = "allow"
             rel = destsuffix.rstrip('/')
             # Only crates that physically live under UNPACKDIR and carry a
             # Cargo.toml are real workspace members.
-            if os.path.exists(os.path.join(unpackdir, rel, 'Cargo.toml')):
+            if os.path.exists(os.path.join(unpack_root, rel, 'Cargo.toml')):
                 members.append(rel)
             else:
                 # Top-level dir of a non-crate destsuffix gets excluded so a
@@ -278,13 +285,30 @@ type_complexity = "allow"
                 if top:
                     excludes.add(top)
 
-    # The edgelet (and any other source tree) under UNPACKDIR has its own
+    # Only synthesize the workspace root when the fetched crates actually use
+    # Cargo workspace inheritance (the 1.6 split-crate layout: `<dep> =
+    # { workspace = true }` / `[lints] workspace = true`). The 1.5.x IIS crates
+    # are self-contained and must NOT receive a synthetic root -- its 1.6
+    # dependency versions would be wrong for them, and 1.5 never inherited from
+    # a workspace so it does not need one. This makes the fix self-activating
+    # per release/version: no-op on 1.5, active on 1.6, on either Yocto line.
+    def _uses_workspace_inheritance(rel):
+        try:
+            with open(os.path.join(unpack_root, rel, 'Cargo.toml')) as fh:
+                txt = fh.read()
+        except OSError:
+            return False
+        return 'workspace = true' in txt or 'workspace.dependencies' in txt
+    if not any(_uses_workspace_inheritance(m) for m in members):
+        return
+
+    # The edgelet (and any other source tree) under the unpack root has its own
     # [workspace]; exclude every top-level dir we did not list as a member so
     # cargo never treats them as part of this synthetic IIS workspace.
     member_tops = {m.split('/', 1)[0] for m in members}
     try:
-        for entry in os.listdir(unpackdir):
-            full = os.path.join(unpackdir, entry)
+        for entry in os.listdir(unpack_root):
+            full = os.path.join(unpack_root, entry)
             if entry in member_tops:
                 continue
             if entry in ('cargo_home',):
@@ -296,7 +320,7 @@ type_complexity = "allow"
 
     if not members:
         bb.warn('iot-identity-service.inc: no IIS workspace members found under '
-                '%s; skipping synthetic workspace root' % unpackdir)
+                '%s; skipping synthetic workspace root' % unpack_root)
         return
 
     members.sort()
@@ -316,7 +340,7 @@ type_complexity = "allow"
     lines.append(iis_workspace_deps.strip())
     lines.append('')
 
-    root = os.path.join(unpackdir, 'Cargo.toml')
+    root = os.path.join(unpack_root, 'Cargo.toml')
     with open(root, 'w') as f:
         f.write('\n'.join(lines))
     bb.note('iot-identity-service.inc: wrote synthetic IIS workspace root %s '

--- a/recipes-core/iotedge/iotedge_1.6.0.bb
+++ b/recipes-core/iotedge/iotedge_1.6.0.bb
@@ -11,6 +11,12 @@ inherit cargo cargo-update-recipe-crates
 SRC_URI += "git://github.com/Azure/iotedge.git;protocol=https;nobranch=1"
 SRCREV = "314983eaa92809521518a95631a22d7a9259a3eb"
 CARGO_SRC_DIR = "edgelet"
+# Yocto release-agnostic source dir: mirror the git fetcher so ONE recipe is
+# correct on both Yocto lines that build it. git unpacks to
+# ${UNPACKDIR:-${WORKDIR}}/${BB_GIT_DEFAULT_DESTSUFFIX:-git}: Scarthgap (5.0)
+# leaves both unset -> ${WORKDIR}/git; Wrynose (6.0) sets them -> ${WORKDIR}/
+# sources/${BP}. A hardcoded /git breaks Wrynose; omitting S breaks Scarthgap.
+S = "${@(d.getVar('UNPACKDIR') or d.getVar('WORKDIR')) + '/' + (d.getVar('BB_GIT_DEFAULT_DESTSUFFIX') or 'git')}"
 CARGO_BUILD_FLAGS += "-p iotedge"
 CARGO_LOCK_SRC_DIR = "${S}/edgelet"
 do_compile[network] = "1"

--- a/recipes-core/iotedge/iotedge_1.6.0.bb
+++ b/recipes-core/iotedge/iotedge_1.6.0.bb
@@ -10,13 +10,13 @@ inherit cargo cargo-update-recipe-crates
 
 SRC_URI += "git://github.com/Azure/iotedge.git;protocol=https;nobranch=1"
 SRCREV = "314983eaa92809521518a95631a22d7a9259a3eb"
-CARGO_SRC_DIR = "edgelet"
 # Yocto release-agnostic source dir: mirror the git fetcher so ONE recipe is
 # correct on both Yocto lines that build it. git unpacks to
 # ${UNPACKDIR:-${WORKDIR}}/${BB_GIT_DEFAULT_DESTSUFFIX:-git}: Scarthgap (5.0)
 # leaves both unset -> ${WORKDIR}/git; Wrynose (6.0) sets them -> ${WORKDIR}/
 # sources/${BP}. A hardcoded /git breaks Wrynose; omitting S breaks Scarthgap.
 S = "${@(d.getVar('UNPACKDIR') or d.getVar('WORKDIR')) + '/' + (d.getVar('BB_GIT_DEFAULT_DESTSUFFIX') or 'git')}"
+CARGO_SRC_DIR = "edgelet"
 CARGO_BUILD_FLAGS += "-p iotedge"
 CARGO_LOCK_SRC_DIR = "${S}/edgelet"
 do_compile[network] = "1"

--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -40,12 +40,26 @@ if [[ $# -lt 1 ]]; then
 fi
 branch=${1}
 
+# Template/codename may differ from the actual Yocto layer branch. The
+# `scarthgap-1.6` template builds IoT Edge 1.6 on Yocto 5.0 (Scarthgap) layers,
+# so it fetches the same upstream layers as `scarthgap` but swaps meta-rust for
+# meta-lts-mixins scarthgap/rust (Rust 1.92, needed for 1.6). Map the template
+# name to the real Yocto branch here.
+YOCTO_BRANCH="${branch}"
+USE_LTS_MIXINS=0
+case "${branch}" in
+    scarthgap-1.6)
+        YOCTO_BRANCH="scarthgap"
+        USE_LTS_MIXINS=1
+        ;;
+esac
+
 # The poky "combo" repo was deprecated upstream starting with Yocto 6.0
 # (Wrynose), so wrynose and later must be assembled from the split repos.
 # Scarthgap (5.0) and earlier still ship the combo poky repo.
 # Default: combo layout, unless the codename is known to need split repos.
 SPLIT_REPO=0
-case "${branch}" in
+case "${YOCTO_BRANCH}" in
     wrynose) SPLIT_REPO=1 ;;  # Yocto 6.0 LTS: split repos (combo deprecated)
 esac
 # Explicit override for future codenames / testing: FORCE_SPLIT_REPO=1|0
@@ -145,22 +159,22 @@ update_repo() {
 METAOE_URI="https://git.openembedded.org/meta-openembedded.git"
 METAOE_UPSTREAM_URI="${METAOE_URI}"
 METAOE_PATH="poky/meta-openembedded"
-METAOE_REV="${METAOE_REV-refs/remotes/origin/${branch}}"
+METAOE_REV="${METAOE_REV-refs/remotes/origin/${YOCTO_BRANCH}}"
 
 METAVIRT_URI="https://git.yoctoproject.org/meta-virtualization"
 METAVIRT_UPSTREAM_URI="${METAVIRT_URI}"
 METAVIRT_PATH="poky/meta-virtualization"
-METAVIRT_REV="${METAVIRT_REV-refs/remotes/origin/${branch}}"
+METAVIRT_REV="${METAVIRT_REV-refs/remotes/origin/${YOCTO_BRANCH}}"
 
 METASECURITY_URI="https://git.yoctoproject.org/meta-security"
 METASECURITY_UPSTREAM_URI="${METASECURITY_URI}"
 METASECURITY_PATH="poky/meta-security"
-METASECURITY_REV="${METASECURITY_REV-refs/remotes/origin/${branch}}"
+METASECURITY_REV="${METASECURITY_REV-refs/remotes/origin/${YOCTO_BRANCH}}"
 
 METACLANG_URI="https://github.com/kraj/meta-clang"
 METACLANG_UPSTREAM_URI="${METACLANG_URI}"
 METACLANG_PATH="poky/meta-clang"
-METACLANG_REV="${METACLANG_REV-refs/remotes/origin/${branch}}"
+METACLANG_REV="${METACLANG_REV-refs/remotes/origin/${YOCTO_BRANCH}}"
 
 METAIOTEDGE_URI="."
 METAIOTEDGE_PATH="poky/meta-iotedge"
@@ -179,7 +193,7 @@ if [[ "${SPLIT_REPO}" == "1" ]]; then
 	# oe-core provides poky/meta + scripts + oe-init-build-env
 	OECORE_URI="https://git.openembedded.org/openembedded-core"
 	OECORE_PATH="poky"
-	OECORE_REV="${OECORE_REV-refs/remotes/origin/${branch}}"
+	OECORE_REV="${OECORE_REV-refs/remotes/origin/${YOCTO_BRANCH}}"
 
 	# bitbake is its own repo on wrynose. oe-core wrynose pairs with bitbake 2.18.
 	BITBAKE_URI="https://git.openembedded.org/bitbake"
@@ -189,7 +203,7 @@ if [[ "${SPLIT_REPO}" == "1" ]]; then
 	# meta-yocto provides meta-poky + meta-yocto-bsp
 	METAYOCTO_URI="https://git.yoctoproject.org/meta-yocto"
 	METAYOCTO_PATH="poky/meta-yocto"
-	METAYOCTO_REV="${METAYOCTO_REV-refs/remotes/origin/${branch}}"
+	METAYOCTO_REV="${METAYOCTO_REV-refs/remotes/origin/${YOCTO_BRANCH}}"
 
 	if [[ "${GIT_MIRROR}" == "github" ]]; then
 		OECORE_URI=$(verify_github_mirror "openembedded-core" "https://github.com/openembedded/openembedded-core.git" "${OECORE_URI}")
@@ -214,18 +228,32 @@ if [[ "${SPLIT_REPO}" == "1" ]]; then
 	ln -sf meta-yocto/meta-yocto-bsp poky/meta-yocto-bsp || die "unable to symlink meta-yocto-bsp"
 else
 	# ---- Scarthgap / Kirkstone combo poky repo ----
-	echo "Using poky combo-repo layout for '${branch}'."
+	echo "Using poky combo-repo layout for '${branch}' (Yocto branch '${YOCTO_BRANCH}')."
 
 	POKY_URI="https://git.yoctoproject.org/poky.git"
 	POKY_UPSTREAM_URI="${POKY_URI}"
 	POKY_PATH="poky"
-	POKY_REV="${POKY_REV-refs/remotes/origin/${branch}}"
+	POKY_REV="${POKY_REV-refs/remotes/origin/${YOCTO_BRANCH}}"
 
-	METARUST_URI="https://github.com/meta-rust/meta-rust"
-	METARUST_PATH="poky/meta-rust"
-	# Pin to 1c4ef8c (before f067576 which broke kirkstone compatibility by using undefined RUST_VERSION)
-	# This provides Rust 1.78.0 which is sufficient for IoT Edge 1.5
-	METARUST_REV="${METARUST_REV-1c4ef8cf7dea391b6a967a13abc61e878a8e778d}"
+	if [[ "${USE_LTS_MIXINS}" == "1" ]]; then
+		# scarthgap-1.6: IoT Edge 1.6 needs newer Rust than Poky Scarthgap
+		# (1.75) provides. Use Yocto's official meta-lts-mixins scarthgap/rust
+		# branch, which ships Rust 1.92.0 and is maintained through Scarthgap
+		# EOL (Apr 2028). 1.92 is sufficient for the whole 1.6 product (IIS +
+		# edgelet both compile clean on 1.92 with the sysinfo 0.38.4 pin the
+		# recipes already carry). The template masks Poky's rust/cargo so this
+		# layer provides the toolchain, mirroring the Kirkstone/meta-rust setup.
+		METAMIXINS_URI="https://git.yoctoproject.org/meta-lts-mixins"
+		METAMIXINS_UPSTREAM_URI="${METAMIXINS_URI}"
+		METAMIXINS_PATH="poky/meta-lts-mixins"
+		METAMIXINS_REV="${METAMIXINS_REV-refs/remotes/origin/scarthgap/rust}"
+	else
+		METARUST_URI="https://github.com/meta-rust/meta-rust"
+		METARUST_PATH="poky/meta-rust"
+		# Pin to 1c4ef8c (before f067576 which broke kirkstone compatibility by using undefined RUST_VERSION)
+		# This provides Rust 1.78.0 which is sufficient for IoT Edge 1.5
+		METARUST_REV="${METARUST_REV-1c4ef8cf7dea391b6a967a13abc61e878a8e778d}"
+	fi
 
 	if [[ "${GIT_MIRROR}" == "github" ]]; then
 		POKY_URI=$(verify_github_mirror "poky" "https://github.com/yoctoproject/poky.git" "${POKY_UPSTREAM_URI}")
@@ -236,7 +264,11 @@ else
 	update_repo "${METAVIRT_URI}"    "${METAVIRT_PATH}"    "${METAVIRT_REV}"
 	update_repo "${METASECURITY_URI}" "${METASECURITY_PATH}" "${METASECURITY_REV}"
 	update_repo "${METACLANG_URI}"   "${METACLANG_PATH}"   "${METACLANG_REV}"
-	update_repo "${METARUST_URI}"    "${METARUST_PATH}"    "${METARUST_REV}"
+	if [[ "${USE_LTS_MIXINS}" == "1" ]]; then
+		update_repo "${METAMIXINS_URI}" "${METAMIXINS_PATH}" "${METAMIXINS_REV}"
+	else
+		update_repo "${METARUST_URI}"    "${METARUST_PATH}"    "${METARUST_REV}"
+	fi
 fi
 
 rm -rf "${METAIOTEDGE_PATH}" || die "unable to clear old ${METAIOTEDGE_PATH}"

--- a/scripts/update-recipes.sh
+++ b/scripts/update-recipes.sh
@@ -7,7 +7,7 @@ Usage: update-recipes.sh [options]
 
 Options:
     --iotedge-version <ver>   IoT Edge version tag (e.g., 1.5.35)
-    --template <name>         Yocto template (kirkstone, scarthgap, or wrynose, default: scarthgap)
+    --template <name>         Yocto template (kirkstone, scarthgap, wrynose, or scarthgap-1.6, default: scarthgap)
     --clean                   Remove old version-specific recipe files before generating
     --skip-validate           Skip bitbake validation (not recommended)
     --workdir <path>          Work directory (default: mktemp)
@@ -56,8 +56,8 @@ if [[ -z "${IOTEDGE_VERSION}" ]]; then
 fi
 
 # Validate template
-if [[ "${TEMPLATE}" != "scarthgap" && "${TEMPLATE}" != "kirkstone" && "${TEMPLATE}" != "wrynose" ]]; then
-    echo "Error: --template must be 'scarthgap', 'kirkstone', or 'wrynose'"
+if [[ "${TEMPLATE}" != "scarthgap" && "${TEMPLATE}" != "kirkstone" && "${TEMPLATE}" != "wrynose" && "${TEMPLATE}" != "scarthgap-1.6" ]]; then
+    echo "Error: --template must be 'scarthgap', 'kirkstone', 'wrynose', or 'scarthgap-1.6'"
     exit 1
 fi
 echo "Using template: ${TEMPLATE}"
@@ -73,7 +73,15 @@ echo "Using template: ${TEMPLATE}"
 #      dir at once. scarthgap/kirkstone keep the legacy shared <pkg>-crates.inc
 #      name they have always used.
 # Keep both shapes byte-identical to what already ships for each series.
-if [[ "${TEMPLATE}" == "wrynose" ]]; then
+#
+# The 1.6 recipe set is shared: it is built by BOTH the Wrynose (6.0) line and
+# the Scarthgap-1.6 (5.0) line. Both must emit the SAME recipe shape (per-version
+# crates.inc + the release-agnostic S expression), so the `scarthgap-1.6`
+# template selects the same shape as `wrynose` here. Do NOT let scarthgap-1.6
+# fall through to the 1.5/legacy ELSE branch: that would emit the shared
+# crates.inc name and a hardcoded S = "${WORKDIR}/git", producing the wrong
+# recipe text and failing the recipe-consistency check.
+if [[ "${TEMPLATE}" == "wrynose" || "${TEMPLATE}" == "scarthgap-1.6" ]]; then
     PER_VERSION_CRATES=true
     # The 1.6 recipe set lives on `main` and is built by BOTH the Wrynose (6.0)
     # line and the Scarthgap-1.6 (5.0) line, which unpack git source to

--- a/scripts/update-recipes.sh
+++ b/scripts/update-recipes.sh
@@ -75,10 +75,26 @@ echo "Using template: ${TEMPLATE}"
 # Keep both shapes byte-identical to what already ships for each series.
 if [[ "${TEMPLATE}" == "wrynose" ]]; then
     PER_VERSION_CRATES=true
-    EMIT_S_GIT=false
+    # The 1.6 recipe set lives on `main` and is built by BOTH the Wrynose (6.0)
+    # line and the Scarthgap-1.6 (5.0) line, which unpack git source to
+    # different paths. A hardcoded S = "${WORKDIR}/git" is correct only on
+    # Scarthgap and hard-errors on Wrynose; omitting S is correct only on
+    # Wrynose and breaks do_patch/cargo on Scarthgap. Emit an expression that
+    # mirrors the git fetcher on either release: source lands at
+    # ${UNPACKDIR:-${WORKDIR}}/${BB_GIT_DEFAULT_DESTSUFFIX:-git}, which resolves
+    # to ${WORKDIR}/git on Scarthgap and ${WORKDIR}/sources/${BP} on Wrynose.
+    S_LINE='# Yocto release-agnostic source dir: mirror the git fetcher so ONE recipe is
+# correct on both Yocto lines that build it. git unpacks to
+# ${UNPACKDIR:-${WORKDIR}}/${BB_GIT_DEFAULT_DESTSUFFIX:-git}: Scarthgap (5.0)
+# leaves both unset -> ${WORKDIR}/git; Wrynose (6.0) sets them -> ${WORKDIR}/
+# sources/${BP}. A hardcoded /git breaks Wrynose; omitting S breaks Scarthgap.
+S = "${@(d.getVar('"'"'UNPACKDIR'"'"') or d.getVar('"'"'WORKDIR'"'"')) + '"'"'/'"'"' + (d.getVar('"'"'BB_GIT_DEFAULT_DESTSUFFIX'"'"') or '"'"'git'"'"')}"'$'\n'
 else
     PER_VERSION_CRATES=false
-    EMIT_S_GIT=true
+    # 1.5 (Scarthgap/Kirkstone, Yocto <=5.0): UNPACKDIR is unset and git unpacks
+    # to ${WORKDIR}/git, so the legacy explicit S is both correct and required
+    # (the default S = ${WORKDIR}/${BP} would point at the wrong dir).
+    S_LINE='S = "${WORKDIR}/git"'$'\n'
 fi
 
 # Check dependencies early (before first use of curl/git/python3)
@@ -370,12 +386,8 @@ for pkg in aziot-edged iotedge; do
         crates_inc="${recipe_dir}/${pkg}-crates.inc"
         crates_require="\${BPN}-crates.inc"
     fi
-    # wrynose (Yocto 6.0) sets S by default and rejects the old explicit value.
-    if [[ "${EMIT_S_GIT}" == true ]]; then
-        s_line='S = "${WORKDIR}/git"'$'\n'
-    else
-        s_line=""
-    fi
+    # S line is series-dependent; computed once above as S_LINE.
+    s_line="${S_LINE}"
 
     # Generate .bb (template — only metadata + SRCREV change between versions)
     cat > "${bb}" <<BBEOF
@@ -467,12 +479,8 @@ for pkg in aziotd aziotctl aziot-keys; do
         crates_inc="${recipe_dir}/${pkg}-crates.inc"
         crates_require="\${BPN}-crates.inc"
     fi
-    # wrynose (Yocto 6.0) sets S by default and rejects the old explicit value.
-    if [[ "${EMIT_S_GIT}" == true ]]; then
-        s_line='S = "${WORKDIR}/git"'$'\n'
-    else
-        s_line=""
-    fi
+    # S line is series-dependent; computed once above as S_LINE.
+    s_line="${S_LINE}"
 
     # aziot-keys builds a cdylib (no binary). On wrynose (Yocto 6.0) the cargo
     # bbclass only installs the .so when CARGO_INSTALL_LIBRARIES is set, so wire


### PR DESCRIPTION
## Summary

Adds support for building **IoT Edge 1.6.x on Yocto 5.0 (Scarthgap)** via a new `scarthgap-1.6` template, for devices that need 1.6 but cannot yet move to Wrynose (Yocto 6.0). The 1.6.x recipes already on `main` are reused unchanged in shape; only the Yocto layers and the Rust toolchain differ.

This revisits the earlier "1.6 → Wrynose only" position, which assumed 1.6 on Scarthgap would require a fragile local Rust backport. That premise no longer holds: Yocto's official [`meta-lts-mixins`](https://git.yoctoproject.org/meta-lts-mixins) `scarthgap/rust` branch provides Rust 1.92.0, maintained through Scarthgap EOL (April 2028), which is sufficient for the entire 1.6 product with no backport.

## What's here

**New template (`conf/templates/scarthgap-1.6/`)**
- Pins `PREFERRED_VERSION_*` to 1.6.0, masks Poky's `rust`/`cargo`, and adds `meta-lts-mixins` `scarthgap/rust` (mirrors the Kirkstone/meta-rust pattern).
- `fetch.sh scarthgap-1.6` maps to the `scarthgap` Yocto branch and clones `meta-lts-mixins` in place of `meta-rust`.

**Build fixes (dual-Yocto-safe)** — the 1.6.0 recipes on `main` are built by both the Wrynose and the new Scarthgap-1.6 line, so both fixes are no-ops on Wrynose:
1. **Source dir (`S`).** git unpacks to `${UNPACKDIR:-${WORKDIR}}/${BB_GIT_DEFAULT_DESTSUFFIX:-git}`, which differs by release: Scarthgap leaves both vars unset (`${WORKDIR}/git`), Wrynose sets them (`${WORKDIR}/sources/${BP}`). The 1.6.0 recipes dropped the explicit `S` that 1.5.x carried, which broke `do_patch`/cargo on Scarthgap. A hardcoded `S = "${WORKDIR}/git"` hard-errors on Wrynose; omitting `S` breaks Scarthgap. The recipes now emit an expression mirroring the git fetcher so one recipe is correct on both lines. Taught to `update-recipes.sh` (the recipe generator) so regeneration stays byte-identical and the CI recipe-consistency check passes.
2. **Synthetic IIS Cargo workspace root (`iot-identity-service.inc`).** The prefunc bailed when `UNPACKDIR` was unset, so on Scarthgap the edgelet's path-redirected `cert/*-async` crates could not inherit `workspace.dependencies` → "failed to find a workspace root". It now roots the synthetic workspace at `UNPACK_ROOT` (`UNPACKDIR` on Wrynose, `WORKDIR` on Scarthgap) and only synthesizes it when the fetched crates actually use workspace inheritance — a no-op on the self-contained 1.5.x crates, active only on 1.6 on either Yocto line.

**Automation**
- **CI (`ci-build.yml`):** `scarthgap-1.6` added as a third PR/push matrix leg, so the aggregate "Build and validate" check covers every shipped line (scarthgap=1.5, wrynose=1.6, scarthgap-1.6=1.6-on-Yocto-5.0). Version→template mapping: a plain `1.6.x` tag stays Wrynose; a `1.6.x-scarthgap` tag selects `scarthgap-1.6`.
- **Release (`release.yml`):** recognizes the `-scarthgap` suffix (template, Yocto label, release notes). The Latest badge is guarded so a Scarthgap-1.6 (compatibility) release never takes Latest from the primary Wrynose 1.6 line, and the previous-tag comparison is scoped per Yocto line.
- **README:** documents the template, the `meta-lts-mixins` 1.92 toolchain approach, the `-scarthgap` release-tag convention, and adds the line to the version/branch table.

## Validation

- Full cross-compiled Scarthgap-1.6 build **green**: 5414 tasks, 0 failed. `iotedge` and `aziot-edged` 1.6.0 RPMs (plus the IIS daemon set) produced, on `meta-lts-mixins` `scarthgap/rust` 1.92.0 with the pre-existing `sysinfo` 0.38.4 pin — no Rust backport.
- The `do_configure` log confirms the fix path: on Scarthgap the synthetic IIS workspace root now lands at `${WORKDIR}` (the `UNPACK_ROOT` fallback), and `iotedge do_compile` (previously failing) succeeds.
- Recipe generator output verified byte-identical to the committed recipes.

## Notes for reviewers

- **Wrynose leg:** the shipping Wrynose recipes now carry an explicit `S` they previously relied on defaults for. It is reasoned-equivalent to the prior default (confirmed by inspecting `UNPACKDIR` + `BB_GIT_DEFAULT_DESTSUFFIX` on the Wrynose checkout), but this branch was validated by building Scarthgap-1.6 locally, not Wrynose. The CI wrynose matrix leg is the intended backstop.
- **Release tag convention:** Scarthgap-1.6 releases use a `-scarthgap` suffix (e.g. `1.6.0-scarthgap`) to stay distinct from the Wrynose `1.6.0` release.
- **Known non-blocking follow-up:** `aziot-edged-dbg` emits a `[buildpaths]` QA warning on Scarthgap (warning, not error; does not fail the build or release). A fix would touch the shared `DEBUG_PREFIX_MAP` and needs a Wrynose re-validation, so it is deferred rather than risk the shipping line in this PR.

Draft while CI runs on the self-hosted 1ES pool.
